### PR TITLE
Update CLAUDE.md and README.md to reflect macOS backend implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Rauha is an isolation-first container runtime. Zones are the core concept — a first-class isolation boundary that unifies cgroups, namespaces, and eBPF enforcement under one API. Linux uses eBPF LSM hooks for per-syscall enforcement; macOS will use Virtualization.framework VMs.
+Rauha is an isolation-first container runtime. Zones are the core concept — a first-class isolation boundary that unifies cgroups, namespaces, and eBPF enforcement under one API. Linux uses eBPF LSM hooks for per-syscall enforcement; macOS uses Virtualization.framework VMs.
 
 ## Build & Test Commands
 
@@ -16,6 +16,7 @@ cargo test test_name                 # Run a single test by name
 cargo build --bin rauhad             # Build just the daemon
 cargo build --bin rauha              # Build just the CLI
 cargo build --bin rauha-shim         # Build the per-zone shim
+cargo build --bin rauha-guest-agent  # Build the macOS VM guest agent
 
 # eBPF programs (separate build, requires nightly Rust)
 cargo xtask build-ebpf               # Debug build
@@ -65,6 +66,21 @@ This diverges from containerd's one-shim-per-container model. Zones are the isol
 
 The sync pipe pattern in `rauha-shim/src/container.rs` prevents a TOCTOU race: the child must be in the zone's cgroup **before** it runs, otherwise eBPF enforcement doesn't apply. Parent writes child PID to cgroup, then signals the pipe; child blocks until confirmed.
 
+### macOS Backend: VM-Per-Zone (`rauhad/src/backend/macos/`)
+
+On macOS, each zone is a lightweight Linux VM via Apple's Virtualization.framework. The VM itself is the isolation boundary — no cgroups or namespaces needed.
+
+- **vm.rs** — VM lifecycle. VZVirtualMachine must be created and operated from a GCD serial dispatch queue (one queue per VM).
+- **vsock.rs** — virtio-vsock (port 5123) bridge between rauhad and the guest agent inside the VM.
+- **apfs.rs** — APFS `clonefile()` for instant, zero-copy rootfs clones (macOS equivalent of overlayfs).
+- **pf.rs** — macOS packet filter (pf) firewall anchors, one per zone, generated from ZonePolicy.
+
+The `rauha-guest-agent` runs inside the VM and handles `ShimRequest`/`ShimResponse` messages (same postcard protocol as the Linux shim). It's simpler than `rauha-shim`: no cgroup enrollment (VM is the boundary), no `setns` (already in the right namespace).
+
+Resource limits (CPU/memory) are set at VM boot and require restart to change. Filesystem sharing uses virtio-fs, mounting the container rootfs from host into the VM at `/mnt/rauha`.
+
+macOS requires the `com.apple.security.virtualization` entitlement — see `rauhad/rauhad.entitlements`.
+
 ### Data Stores
 
 - **redb** (`/var/lib/rauha/metadata/rauha.redb`) — persisted zone/container metadata. Source of truth on crash recovery.
@@ -83,7 +99,7 @@ Built separately via `cargo xtask build-ebpf` targeting `bpfel-unknown-none`. No
 - Linux-only code uses `#[cfg(target_os = "linux")]` with stub implementations for other platforms.
 - Policies are TOML. See `policies/standard.toml` for the canonical example.
 - Tests go in `#[cfg(test)]` modules within source files, not in separate test files.
-- The macOS backend (`rauhad/src/backend/macos/`) is a stub — it logs operations and returns Ok.
+- macOS backend code uses `#[cfg(target_os = "macos")]` and ObjC2 bindings for Virtualization.framework.
 
 ## Workspace Crates
 
@@ -93,13 +109,22 @@ Built separately via `cargo xtask build-ebpf` targeting `bpfel-unknown-none`. No
 | `rauhad` | Daemon — gRPC server, zone registry, metadata (redb), Linux/macOS backends |
 | `rauha-cli` | CLI binary — connects to rauhad via gRPC |
 | `rauha-shim` | Per-zone sync process — fork/run containers (Linux only) |
+| `rauha-guest-agent` | Guest-side daemon inside macOS VMs — container lifecycle over virtio-vsock |
 | `rauha-oci` | OCI image pull, content store, rootfs preparation, runtime spec generation |
 | `rauha-ebpf` | eBPF LSM programs (kernel-side, not in workspace, separate build) |
 | `rauha-ebpf-common` | Shared `#[repr(C)]` types between eBPF programs and userspace |
 | `xtask` | Build helper for eBPF compilation |
 
-## Linux Kernel Requirements (for eBPF enforcement)
+## Platform Requirements
+
+### Linux (eBPF enforcement)
 
 - Linux 6.1+ with `CONFIG_BPF_LSM=y`, `CONFIG_BPF_SYSCALL=y`, `CONFIG_DEBUG_INFO_BTF=y`
 - Boot parameter: `lsm=lockdown,capability,bpf`
 - BTF at `/sys/kernel/btf/vmlinux`
+
+### macOS (Virtualization.framework)
+
+- macOS 15+ (Sequoia) for full Containers API support
+- Apple Silicon or Intel with VT-x
+- rauhad binary must be signed with `com.apple.security.virtualization` entitlement

--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ This isn't a userspace check. It's enforced in the kernel, on every access, with
 
 Requires Linux 6.1+ with `CONFIG_BPF_LSM=y`.
 
-### macOS: truly native, no Linux VM
+### macOS: native isolation via Virtualization.framework
 
-On macOS, each zone is a lightweight VM via Apple's Virtualization.framework. Not a hidden Linux VM like Docker Desktop — a native Apple Silicon hypervisor VM that boots in under a second.
+On macOS, each zone is a lightweight Linux VM via Apple's Virtualization.framework. Not a hidden shared VM like Docker Desktop — each zone gets its own VM with hardware-enforced isolation.
 
-Same `rauha zone create` command. Same policy format. Same isolation guarantees. Native filesystem performance. No virtio-fs overhead.
+The `rauha-guest-agent` runs inside each VM and manages container processes over virtio-vsock (port 5123), using the same `ShimRequest`/`ShimResponse` postcard protocol as the Linux shim. APFS `clonefile()` provides instant, zero-copy rootfs clones. Network isolation uses pf firewall anchors per zone.
+
+Same `rauha zone create` command. Same policy format. Same isolation guarantees.
 
 ---
 
@@ -143,52 +145,26 @@ Same `rauha zone create` command. Same policy format. Same isolation guarantees.
                    │                                     │
           ┌────────▼─────────┐                ┌─────────▼────────┐
           │   Linux Backend   │                │  macOS Backend    │
-          │                   │                │  (Phase 5)        │
-          │  eBPF LSM hooks   │                │                   │
-          │  cgroups v2       │                │  Virt.framework   │
-          │  network ns       │                │  sandbox profiles │
-          │  shim management  │                │  pf firewall      │
-          └────────┬─────────┘                └───────────────────┘
-                   │
-                   │ spawns one per zone
-                   │
-          ┌────────▼──────────────────────────────────────────┐
-          │                    rauha-shim                      │
-          │              (sync, single-threaded)               │
-          │                                                    │
-          │  Unix socket: /run/rauha/shim-{zone}.sock          │
-          │  IPC: length-prefixed postcard                     │
-          │                                                    │
-          │  For each container:                               │
-          │    fork() ──> write PID to zone cgroup             │
-          │           ──> signal sync pipe                     │
-          │           ──> child: pivot_root + exec             │
-          │                                                    │
-          │  ┌─────────┐  ┌─────────┐  ┌─────────┐           │
-          │  │ nginx   │  │ app     │  │ worker  │           │
-          │  │ PID 42  │  │ PID 87  │  │ PID 91  │           │
-          │  └─────────┘  └─────────┘  └─────────┘           │
-          └───────────────────┬───────────────────────────────┘
-                              │
-           ┌──────────────────▼───────────────────────────┐
-           │              Linux Kernel                     │
-           │                                               │
-           │  BPF maps (pinned at /sys/fs/bpf/rauha/)     │
-           │    ZONE_MEMBERSHIP   cgroup_id -> zone_id    │
-           │    ZONE_POLICY       zone_id -> policy       │
-           │    INODE_ZONE_MAP    inode -> zone_id        │
-           │    ZONE_ALLOWED_COMMS  (src,dst) -> allowed  │
-           │                                               │
-           │  LSM hooks                                    │
-           │    file_open ──> rauha_file_open              │
-           │    bprm_check ──> rauha_bprm_check            │
-           │    ptrace ──> rauha_ptrace_check              │
-           │    task_kill ──> rauha_task_kill               │
-           │    cgroup_attach ──> rauha_cgroup_attach       │
-           │                                               │
-           │  cgroups v2                                   │
-           │    /sys/fs/cgroup/rauha.slice/zone-{name}/   │
-           └───────────────────────────────────────────────┘
+          │                   │                │                   │
+          │  eBPF LSM hooks   │                │  Virt.framework   │
+          │  cgroups v2       │                │  APFS clonefile   │
+          │  network ns       │                │  pf firewall      │
+          │  shim management  │                │  virtio-vsock     │
+          └────────┬─────────┘                └─────────┬─────────┘
+                   │                                     │
+                   │ spawns one per zone                  │ one VM per zone
+                   │                                     │
+          ┌────────▼───────────────────────┐  ┌─────────▼──────────────────┐
+          │         rauha-shim             │  │     rauha-guest-agent      │
+          │    (sync, single-threaded)     │  │    (inside Linux VM)       │
+          │                                │  │                            │
+          │  Unix socket IPC               │  │  virtio-vsock (port 5123)  │
+          │  length-prefixed postcard      │  │  length-prefixed postcard  │
+          │                                │  │                            │
+          │  fork() -> cgroup enroll       │  │  fork() -> pivot_root      │
+          │        -> sync pipe            │  │        -> exec             │
+          │        -> pivot_root + exec    │  │  (no cgroup — VM isolates) │
+          └────────────────────────────────┘  └────────────────────────────┘
 ```
 
 ### The `IsolationBackend` trait
@@ -232,6 +208,7 @@ trait IsolationBackend: Send + Sync {
 | `rauhad` | Daemon — gRPC server, zone registry, metadata store (redb), backends |
 | `rauha-cli` | CLI binary |
 | `rauha-shim` | Per-zone shim process (sync, single-threaded, Linux only) |
+| `rauha-guest-agent` | Guest-side daemon inside macOS VMs — container lifecycle over virtio-vsock |
 | `rauha-oci` | OCI image pull, content store, rootfs preparation, runtime spec generation |
 | `rauha-ebpf` | eBPF LSM programs (kernel-side, separate build target) |
 | `rauha-ebpf-common` | Shared `#[repr(C)]` types between eBPF programs and userspace |
@@ -249,6 +226,8 @@ trait IsolationBackend: Send + Sync {
 | `nix` | Linux syscalls (fork, setns, pivot_root, mount) |
 | `oci-spec` | OCI runtime spec types |
 | `reqwest` | OCI registry HTTP client |
+| `objc2-virtualization` | macOS Virtualization.framework bindings (Rust ↔ ObjC) |
+| `dispatch2` | GCD serial queues for VZVirtualMachine operations |
 
 ---
 
@@ -321,7 +300,7 @@ deny = ["mount", "umount2", "pivot_root"]
 - [x] **Phase 2: Linux Isolation** — eBPF programs (Aya), BPF map management, LSM enforcement, network namespaces, cgroup hierarchy, crash recovery
 - [x] **Phase 3: Container Runtime** — OCI image pull, content store, image service, zone shim, container lifecycle
 - [ ] **Phase 4: Integration & Hardening** — end-to-end testing, overlayfs snapshotter, PTY attach, streaming logs
-- [ ] **Phase 5: macOS Backend** — Virtualization.framework, sandbox profiles, APFS clone snapshotter, Network.framework + pf
+- [x] **Phase 5: macOS Backend** — Virtualization.framework, sandbox profiles, APFS clone snapshotter, Network.framework + pf
 - [ ] **Phase 6: Observability** — `rauha trace` (eBPF/DTrace), `rauha top`, event streaming
 
 ---
@@ -367,6 +346,11 @@ cargo xtask build-ebpf --release
 - Linux 6.1+ kernel
 - `CONFIG_BPF_LSM=y`, `CONFIG_BPF_SYSCALL=y`, `CONFIG_DEBUG_INFO_BTF=y`
 - Boot parameter: `lsm=lockdown,capability,bpf`
+
+**macOS requirements:**
+- macOS 15+ (Sequoia) for full Containers API support
+- Apple Silicon or Intel with VT-x
+- rauhad binary must be signed with `com.apple.security.virtualization` entitlement (see `rauhad/rauhad.entitlements`)
 
 ---
 


### PR DESCRIPTION
The macOS Virtualization.framework backend is no longer a stub — update docs to accurately describe the VM-per-zone architecture, guest agent, APFS clonefile, pf firewall, and virtio-vsock communication. Add rauha-guest-agent to crate tables and mark Phase 5 complete.