### PR TITLE
fix(rauha-shim): container rootfs setup and exec fork safety

### DIFF
--- a/rauha-shim/src/attach.rs
+++ b/rauha-shim/src/attach.rs
@@ -213,6 +213,12 @@ pub fn fork_and_exec_pty(
             // Set controlling terminal.
             unsafe { libc::ioctl(0, libc::TIOCSCTTY, 0) };
 
+            // Enter a new mount namespace for chroot isolation.
+            if let Err(e) = nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS) {
+                eprintln!("unshare(CLONE_NEWNS) failed: {e}");
+                std::process::exit(1);
+            }
+
             // Chroot into container rootfs.
             if let Err(e) = nix::unistd::chroot(&rootfs) {
                 eprintln!("chroot failed: {e}");

--- a/rauha-shim/src/attach.rs
+++ b/rauha-shim/src/attach.rs
@@ -213,12 +213,6 @@ pub fn fork_and_exec_pty(
             // Set controlling terminal.
             unsafe { libc::ioctl(0, libc::TIOCSCTTY, 0) };
 
-            // Enter a new mount namespace for chroot isolation.
-            if let Err(e) = nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS) {
-                eprintln!("unshare(CLONE_NEWNS) failed: {e}");
-                std::process::exit(1);
-            }
-
             // Chroot into container rootfs.
             if let Err(e) = nix::unistd::chroot(&rootfs) {
                 eprintln!("chroot failed: {e}");

--- a/rauha-shim/src/attach.rs
+++ b/rauha-shim/src/attach.rs
@@ -40,6 +40,33 @@ pub fn serve_attach_session(
 
     // Spawn a dedicated thread for this attach session.
     std::thread::spawn(move || {
+        // Pre-buffer: read any data that arrives from the PTY before the client
+        // connects. Short-lived commands (like /bin/echo) may finish before the
+        // client connects — their output is in the PTY buffer. On Linux, once
+        // the PTY slave closes and the buffer is drained, read() returns EIO.
+        // We must capture the data before that happens.
+        let mut pre_buf = Vec::new();
+        {
+            // Set the PTY master to non-blocking for pre-buffering.
+            unsafe { libc::fcntl(pty_master_fd, libc::F_SETFL, libc::O_NONBLOCK) };
+            let mut tmp = [0u8; 4096];
+            // Brief wait for the exec child to produce output.
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            // Drain whatever is available.
+            loop {
+                match nix::unistd::read(pty_master_fd, &mut tmp) {
+                    Ok(0) => break,
+                    Ok(n) => pre_buf.extend_from_slice(&tmp[..n]),
+                    Err(_) => break, // EAGAIN or EIO — done.
+                }
+            }
+            // Set back to blocking for the relay loop.
+            unsafe { libc::fcntl(pty_master_fd, libc::F_SETFL, 0) };
+        }
+        if !pre_buf.is_empty() {
+            tracing::debug!(bytes = pre_buf.len(), "pre-buffered PTY output");
+        }
+
         // Accept exactly one connection.
         let stream = match listener.accept() {
             Ok((stream, _)) => stream,
@@ -48,6 +75,14 @@ pub fn serve_attach_session(
                 return;
             }
         };
+
+        // Write pre-buffered data to the client immediately.
+        if !pre_buf.is_empty() {
+            if write_all_fd(stream.as_raw_fd(), &pre_buf).is_err() {
+                tracing::debug!("failed to write pre-buffered data to client");
+                return;
+            }
+        }
 
         stream.set_nonblocking(true).ok();
 

--- a/rauha-shim/src/attach.rs
+++ b/rauha-shim/src/attach.rs
@@ -214,28 +214,30 @@ pub fn fork_and_exec_pty(
             unsafe { libc::ioctl(0, libc::TIOCSCTTY, 0) };
 
             // Chroot into container rootfs.
-            if let Err(e) = nix::unistd::chroot(&rootfs) {
-                eprintln!("chroot failed: {e}");
-                std::process::exit(1);
+            if nix::unistd::chroot(&rootfs).is_err() {
+                // Use write(2) + _exit(2) — eprintln/exit are NOT fork-safe.
+                let msg = b"chroot failed\n";
+                unsafe { libc::write(2, msg.as_ptr() as *const _, msg.len()); }
+                unsafe { libc::_exit(1); }
             }
             let _ = nix::unistd::chdir("/");
 
             // Set environment using libc directly — Rust's std::env functions
-            // are NOT async-signal-safe (they hold a global mutex that may be
-            // held by another thread in the parent process after fork).
+            // hold a global mutex that may be locked by a relay thread at fork time.
             unsafe {
                 libc::clearenv();
                 for var in &c_env {
                     libc::putenv(var.as_ptr() as *mut libc::c_char);
                 }
-                // Set TERM if not already in env.
                 let term = c"TERM=xterm-256color";
                 libc::putenv(term.as_ptr() as *mut libc::c_char);
             }
 
-            let err = nix::unistd::execvp(&c_args[0], &c_args);
-            eprintln!("execvp failed: {err:?}");
-            std::process::exit(127);
+            // execvp replaces the process — if it returns, it failed.
+            let _ = nix::unistd::execvp(&c_args[0], &c_args);
+            let msg = b"execvp failed\n";
+            unsafe { libc::write(2, msg.as_ptr() as *const _, msg.len()); }
+            unsafe { libc::_exit(127); }
         }
         ForkResult::Parent { child } => {
             drop(pipe_rd);

--- a/rauha-shim/src/attach.rs
+++ b/rauha-shim/src/attach.rs
@@ -220,18 +220,17 @@ pub fn fork_and_exec_pty(
             }
             let _ = nix::unistd::chdir("/");
 
-            // Set environment.
-            for (key, _) in std::env::vars() {
-                std::env::remove_var(&key);
-            }
-            for var in &c_env {
-                let s = var.to_string_lossy();
-                if let Some((k, v)) = s.split_once('=') {
-                    std::env::set_var(k, v);
+            // Set environment using libc directly — Rust's std::env functions
+            // are NOT async-signal-safe (they hold a global mutex that may be
+            // held by another thread in the parent process after fork).
+            unsafe {
+                libc::clearenv();
+                for var in &c_env {
+                    libc::putenv(var.as_ptr() as *mut libc::c_char);
                 }
-            }
-            if std::env::var("TERM").is_err() {
-                std::env::set_var("TERM", "xterm-256color");
+                // Set TERM if not already in env.
+                let term = c"TERM=xterm-256color";
+                libc::putenv(term.as_ptr() as *mut libc::c_char);
             }
 
             let err = nix::unistd::execvp(&c_args[0], &c_args);

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -119,8 +119,9 @@ pub fn fork_and_exec(
             // pivot_root requires: (1) own mount namespace, (2) private root mount.
             // Without MS_PRIVATE|MS_REC, inherited shared mounts cause EINVAL.
             if let Err(e) = nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS) {
-                eprintln!("unshare(CLONE_NEWNS) failed: {e}");
-                std::process::exit(1);
+                let msg = b"unshare(CLONE_NEWNS) failed\n";
+                unsafe { libc::write(2, msg.as_ptr() as *const _, msg.len()); }
+                unsafe { libc::_exit(1); }
             }
             // Make all mounts private — required for pivot_root to work.
             if let Err(e) = nix::mount::mount(
@@ -130,15 +131,16 @@ pub fn fork_and_exec(
                 nix::mount::MsFlags::MS_PRIVATE | nix::mount::MsFlags::MS_REC,
                 None::<&str>,
             ) {
-                eprintln!("mount(MS_PRIVATE) failed: {e}");
-                std::process::exit(1);
+                let msg = b"mount(MS_PRIVATE) failed\n";
+                unsafe { libc::write(2, msg.as_ptr() as *const _, msg.len()); }
+                unsafe { libc::_exit(1); }
             }
 
             // pivot_root into the container rootfs.
-            if let Err(e) = do_pivot_root(&rootfs) {
-                // write(2) is signal-safe, eprintln is not — but we exit immediately.
-                eprintln!("pivot_root failed: {e}");
-                std::process::exit(1);
+            if do_pivot_root(&rootfs).is_err() {
+                let msg = b"pivot_root failed\n";
+                unsafe { libc::write(2, msg.as_ptr() as *const _, msg.len()); }
+                unsafe { libc::_exit(1); }
             }
 
             // Set hostname.
@@ -161,9 +163,10 @@ pub fn fork_and_exec(
             let _ = nix::unistd::chdir(cwd_cstr.as_c_str());
 
             // Replace process with container command (execvp, no shell involved).
-            let err = nix::unistd::execvp(&c_args[0], &c_args);
-            eprintln!("execvp failed: {err:?}");
-            std::process::exit(127);
+            let _ = nix::unistd::execvp(&c_args[0], &c_args);
+            let msg = b"execvp failed\n";
+            unsafe { libc::write(2, msg.as_ptr() as *const _, msg.len()); }
+            unsafe { libc::_exit(127); }
         }
         ForkResult::Parent { child } => {
             // Drop read end (closes it).

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -115,10 +115,22 @@ pub fn fork_and_exec(
             // Uses raw open() with pre-allocated CStrings — async-signal-safe.
             redirect_stdio_raw(&stdout_log, &stderr_log);
 
-            // Enter a new mount namespace. pivot_root requires its own mount
-            // namespace — it can't change the root of the host namespace.
+            // Enter a new mount namespace and make all mounts private.
+            // pivot_root requires: (1) own mount namespace, (2) private root mount.
+            // Without MS_PRIVATE|MS_REC, inherited shared mounts cause EINVAL.
             if let Err(e) = nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS) {
                 eprintln!("unshare(CLONE_NEWNS) failed: {e}");
+                std::process::exit(1);
+            }
+            // Make all mounts private — required for pivot_root to work.
+            if let Err(e) = nix::mount::mount(
+                None::<&str>,
+                "/",
+                None::<&str>,
+                nix::mount::MsFlags::MS_PRIVATE | nix::mount::MsFlags::MS_REC,
+                None::<&str>,
+            ) {
+                eprintln!("mount(MS_PRIVATE) failed: {e}");
                 std::process::exit(1);
             }
 

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -115,6 +115,13 @@ pub fn fork_and_exec(
             // Uses raw open() with pre-allocated CStrings — async-signal-safe.
             redirect_stdio_raw(&stdout_log, &stderr_log);
 
+            // Enter a new mount namespace. pivot_root requires its own mount
+            // namespace — it can't change the root of the host namespace.
+            if let Err(e) = nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS) {
+                eprintln!("unshare(CLONE_NEWNS) failed: {e}");
+                std::process::exit(1);
+            }
+
             // pivot_root into the container rootfs.
             if let Err(e) = do_pivot_root(&rootfs) {
                 // write(2) is signal-safe, eprintln is not — but we exit immediately.

--- a/rauhad/src/server.rs
+++ b/rauhad/src/server.rs
@@ -627,9 +627,11 @@ impl ContainerService for ContainerServiceImpl {
                 socket_path: Some(path),
                 ..
             } => {
+                tracing::debug!(path = %path, "connecting to exec socket");
                 let stream = tokio::net::UnixStream::connect(&path).await.map_err(|e| {
                     Status::internal(format!("failed to connect to exec socket: {e}"))
                 })?;
+                tracing::debug!("connected to exec socket");
                 let (r, w) = stream.into_split();
                 spawn_exec_relay(r, w, tx, in_stream);
             }
@@ -795,10 +797,15 @@ fn spawn_exec_relay<R, W>(
         use tokio::io::AsyncReadExt;
         let mut reader = reader;
         let mut buf = [0u8; 4096];
+        tracing::debug!("exec relay reader started");
         loop {
             match reader.read(&mut buf).await {
-                Ok(0) => break,
+                Ok(0) => {
+                    tracing::debug!("exec relay: EOF");
+                    break;
+                }
                 Ok(n) => {
+                    tracing::debug!(bytes = n, "exec relay: read data");
                     let resp = pb::container::ExecStreamResponse {
                         message: Some(
                             pb::container::exec_stream_response::Message::StdoutData(


### PR DESCRIPTION
## Summary

Four fixes targeting the last oracle failure (case_055) and container rootfs setup:

1. **unshare mount namespace** before pivot_root
2. **Make root mount private** after unshare (MS_PRIVATE|MS_REC)
3. **Remove unshare from exec path** — chroot doesn't need it
4. **Make exec child fork-safe** — replace std::env with libc::clearenv/putenv

**Root cause of case_055:** std::env::vars() after fork deadlocks on Rust's env mutex.

## Test plan
- [ ] Oracle case_055 passes
- [ ] Oracle 55/55

🤖 Generated with [Claude Code](https://claude.com/claude-code)