### PR TITLE
docs: reposition Rauha around agent sandbox runtime + sandbox result types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Rauha is an isolation-first container runtime. Zones are the core concept — a first-class isolation boundary that unifies cgroups, namespaces, and eBPF enforcement under one API. Linux uses eBPF LSM hooks for per-syscall enforcement; macOS uses Virtualization.framework VMs.
+Rauha is an agent sandbox runtime built on controlled execution zones. A zone is the task/workload boundary that ties together filesystem view, processes, networking, resources, policy, logs, audit events, and optional enforcement events.
+
+The product hierarchy is load-bearing:
+
+1. Agent sandbox runtime.
+2. Zone-based runtime foundation.
+3. Kubernetes/containerd and existing-workload deployment paths.
+
+Do not present Rauha as primarily an eBPF project or a Kubernetes runtime. Rauha creates the zones. Syva makes the Linux kernel respect them. Current Linux eBPF code may still live in this repository, but architecturally it belongs behind the Syva enforcement boundary.
 
 ## Build & Test Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,6 +2304,7 @@ dependencies = [
  "chrono",
  "postcard",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "toml",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -1,336 +1,345 @@
 # Rauha
 
-**Kernel-level enforcement and observability for container isolation.**
+Agent sandbox runtime for controlled, observable execution.
 
-Docker gives you namespaces and cgroups. That's structural isolation — it sets up walls, but nothing watches the doors. A process can't see across a namespace boundary, but the kernel doesn't know that two containers *shouldn't* talk to each other. There's no enforcement at the syscall level, no audit trail of what was allowed or denied, no way to prove a workload stayed inside its boundary.
+Rauha is a sandbox runtime for AI agents, built on controlled execution zones.
+It runs agent tasks where they can be bounded, observed, audited, and later
+enforced by the platform underneath them.
 
-Rauha adds what's missing. Five eBPF LSM hooks run inside the kernel on every `open()`, `exec()`, `kill()`, `ptrace()`, and `cgroup_attach()`. Every call is checked against zone membership. Every deny is recorded with the process, the zone, and the target. This works on any cgroup-based workload — Rauha's own containers, or containers managed by containerd, Docker, or Kubernetes.
+## Why Rauha Exists
 
-**Two ways to use Rauha:**
+Agents do not just answer questions anymore.
 
-- **Rauha runtime** — a standalone container runtime where zones are first-class. Zones unify cgroups, namespaces, and eBPF enforcement under one API. Integrates with Kubernetes via a containerd shim v2. Linux uses eBPF LSM; macOS uses Virtualization.framework VMs.
+They run commands, inspect repositories, modify files, generate patches, call
+APIs, open sockets, spawn processes, and execute tools.
 
-- **[Syvä](https://github.com/false-systems/syva)** — the drop-on enforcement layer for existing clusters has been extracted into its own product. Different audience, different brand: keep your stack, Syvä adds eBPF enforcement on top.
+Most of that execution still happens in environments designed for human
+operators:
 
-**Why this matters for AI infrastructure:**
+- local shells
+- CI runners
+- Docker containers
+- Kubernetes jobs
+- ad-hoc sandboxes
 
-AI agents execute arbitrary code. Training jobs touch sensitive data. Model weights are high-value IP. GPU workloads share nodes. The isolation story for all of this is "a Docker container" — which means a shared kernel and hope.
+Those environments provide structure, but not a clear task-level execution
+contract. Rauha gives each agent task a zone: an isolated, policy-bound runtime
+boundary with structured execution results and auditability.
 
-Rauha's eBPF hooks give you enforceable, auditable isolation: an agent sandbox where you can prove the agent never read files outside its zone. A training job where you have kernel-level evidence of which datasets were accessed. Millisecond zone startup with no VM boot overhead. Every enforcement decision streamed in real time for compliance and anomaly detection.
+## The Short Version
 
-> *Rauha* (Finnish) — peace, calm. What your production systems should be.
+Rauha runs each task inside a zone.
 
-## The Zone Model
+A zone is the boundary around execution:
 
-A zone is not a namespace. It's not a cgroup. It's the *concept* that ties them together.
+- filesystem
+- processes
+- networking
+- resources
+- policy
+- logs
+- audit events
+- enforcement events
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                   Global Zone (Host)                    │
-│                                                         │
-│   rauhad ─── gRPC :9876 ──── rauha CLI                 │
-│                                                         │
-│   ┌─────────────────────┐   ┌─────────────────────┐    │
-│   │       Zone A        │   │       Zone B         │    │
-│   │                     │   │                      │    │
-│   │   nginx             │   │   postgres           │    │
-│   │   app-server        │   │   redis              │    │
-│   │                     │   │                      │    │
-│   │   10.89.0.2/16      │   │   10.89.0.3/16       │    │
-│   │   own cgroup        │   │   own cgroup          │    │
-│   │   own netns         │   │   own netns           │    │
-│   │   own rootfs        │   │   own rootfs          │    │
-│   └─────────────────────┘   └──────────────────────┘    │
-│              ╳ denied by default ╳                       │
-└─────────────────────────────────────────────────────────┘
-```
+For an agent, a zone is the sandbox around a task. For a container, a zone is
+the runtime boundary around a workload. For Kubernetes, a zone can back a pod
+or workload. On Linux, Syva can enforce those boundaries inside the kernel.
 
-Every container belongs to exactly one zone. Zones are the unit of:
+Rauha is an agent sandbox runtime built on a zone-based container runtime, with
+Kubernetes integration as one deployment path.
 
-| Concern | What it means |
-|---------|---------------|
-| **Visibility** | Processes in Zone A cannot see Zone B's processes |
-| **Access** | Files, IPC, and signals cannot cross zone boundaries |
-| **Networking** | Each zone gets its own IP, bridge connectivity, and firewall rules |
-| **Resources** | CPU, memory, I/O, and PID limits scoped per zone |
-| **Policy** | TOML-based, allow-list only, hot-reloadable without restart |
+## Agent Sandboxing
 
-Cross-zone communication requires an explicit policy rule — allow-list, not deny-list.
+The intended task-level user experience is:
 
-## How It Works
-
-### Linux: eBPF makes the kernel zone-aware
-
-Rauha loads eBPF programs into kernel LSM hooks that enforce zone boundaries at the syscall level. Every `open()`, `kill()`, `connect()`, and `ptrace()` checks zone membership before proceeding.
-
-```
-Process in Zone A calls open("/data/file.txt")
-  │
-  ├─ kernel reaches file_open LSM hook
-  ├─ rauha eBPF program fires
-  ├─ lookup: process cgroup → zone_id = A
-  ├─ lookup: file inode → file_zone = B
-  ├─ A ≠ B → return -EACCES
-  │
-  └─ process gets "Permission denied"
+```bash
+rauha sandbox --image python:3.12 --repo . -- pytest tests/
 ```
 
-This isn't a userspace check — it's enforced in the kernel on every access with no daemon round-trip. Policy changes are a BPF map update, not a process restart.
+Structured output should look like:
 
-| eBPF Program | LSM Hook | Blocks |
-|-------------|----------|--------|
-| `rauha_file_open` | `file_open` | Cross-zone file access |
-| `rauha_bprm_check` | `bprm_check_security` | Cross-zone binary execution |
-| `rauha_ptrace_check` | `ptrace_access_check` | Cross-zone debugging/tracing |
-| `rauha_task_kill` | `task_kill` | Cross-zone signals |
-| `rauha_cgroup_attach` | `cgroup_attach_task` | Zone escape via cgroup manipulation |
-
-Every deny is emitted to a ring buffer with the caller PID, zone IDs, and context (inode, cgroup ID) for audit and debugging.
-
-Requires Linux 6.1+ with `CONFIG_BPF_LSM=y`.
-
-### macOS: native VMs via Virtualization.framework
-
-Each zone is a lightweight Linux VM — not a hidden shared VM like Docker Desktop. Each zone gets its own VM with hardware-enforced isolation.
-
-The `rauha-guest-agent` runs inside each VM and manages container processes over virtio-vsock, using the same postcard IPC protocol as the Linux shim. APFS `clonefile()` provides instant, zero-copy rootfs clones. Network isolation uses pf firewall anchors per zone.
-
-Same CLI. Same policy format. Same guarantees.
-
-### Zone Networking
-
-Each zone gets a unique IP from the `10.89.0.0/16` subnet. The `rauha0` bridge acts as gateway. nftables handles NAT masquerade for internet access and per-zone forward chains for traffic filtering.
-
-```
-Zone A (10.89.0.2)                    Zone B (10.89.0.3)
-    │                                     │
-  eth0 ──── veth-a ─┐       ┌── veth-b ── eth0
-                    │       │
-              ┌─────┴───────┴─────┐
-              │     rauha0        │
-              │   10.89.0.1/16    │
-              │   (bridge+gw)     │
-              └────────┬──────────┘
-                       │
-                 IP forwarding
-                       │
-                nftables NAT
-                (masquerade)
-                       │
-                 host interface
-                       │
-                    internet
-```
-
-**Enforcement layering:** nftables handles packet filtering (L3/L4). eBPF `ZONE_ALLOWED_COMMS` map provides defense-in-depth for cross-zone socket operations. Network namespaces provide structural isolation. Three independent layers — if one is bypassed, the others still hold.
-
-## Architecture
-
-```
-┌──────────────────┐
-│    rauha CLI     │
-└────────┬─────────┘
-         │ gRPC :9876
-┌────────▼─────────────────────────────────────────────┐
-│                        rauhad                        │
-│                                                      │
-│  Zone Registry ── Policy Engine ── Metadata (redb)   │
-│       │                                              │
-│  IsolationBackend (trait)                            │
-│       │                                              │
-│  Image Service ── Content Store ── IP Allocator      │
-└───────┬──────────────────────────────────┬───────────┘
-        │                                  │
-┌───────▼──────────┐            ┌──────────▼───────────┐
-│  Linux Backend   │            │   macOS Backend      │
-│                  │            │                      │
-│  eBPF LSM hooks  │            │  Virtualization.fw   │
-│  cgroups v2      │            │  APFS clonefile      │
-│  network ns      │            │  pf firewall         │
-│  nftables NAT    │            │  virtio-vsock        │
-│  IP allocator    │            │  VM-per-zone         │
-└───────┬──────────┘            └──────────┬───────────┘
-        │ one per zone                     │ one VM per zone
-┌───────▼──────────┐            ┌──────────▼───────────┐
-│   rauha-shim     │            │ rauha-guest-agent    │
-│ sync, fork-safe  │            │   inside Linux VM    │
-│ Unix socket IPC  │            │   vsock port 5123    │
-│ postcard codec   │            │   postcard codec     │
-└──────────────────┘            └──────────────────────┘
-```
-
-### The `IsolationBackend` trait
-
-The key abstraction. Both backends implement the same interface — `rauhad` is platform-agnostic.
-
-```rust
-trait IsolationBackend: Send + Sync {
-    fn create_zone(&self, config: &ZoneConfig) -> Result<ZoneHandle>;
-    fn destroy_zone(&self, zone: &ZoneHandle) -> Result<()>;
-    fn enforce_policy(&self, zone: &ZoneHandle, policy: &ZonePolicy) -> Result<()>;
-    fn hot_reload_policy(&self, zone: &ZoneHandle, policy: &ZonePolicy) -> Result<()>;
-    fn create_container(&self, zone: &ZoneHandle, spec: &ContainerSpec) -> Result<ContainerHandle>;
-    fn start_container(&self, container: &ContainerHandle) -> Result<u32>;
-    fn stop_container(&self, container: &ContainerHandle) -> Result<()>;
-    fn zone_stats(&self, zone: &ZoneHandle) -> Result<ZoneStats>;
-    fn verify_isolation(&self, zone: &ZoneHandle) -> Result<IsolationReport>;
-    fn recover_zone(&self, zone: &ZoneHandle, zone_type: ZoneType, policy: &ZonePolicy) -> Result<()>;
-    fn cleanup_orphans(&self, known_zones: &[ZoneHandle]) -> Result<()>;
-    fn isolation_model(&self) -> IsolationModel; // SyscallPolicy | HardwareBoundary
-    fn name(&self) -> &str;
+```json
+{
+  "task_id": "task_123",
+  "zone_id": "zone_456",
+  "command": ["pytest", "tests/"],
+  "status": "succeeded",
+  "exit_code": 0,
+  "duration_ms": 1842,
+  "stdout": "...",
+  "stderr": "",
+  "events": [],
+  "enforcement_events": []
 }
 ```
 
-### Crate Structure
+Status: planned. The repository currently has zone and container lifecycle
+commands, plus a structured sandbox result type in `rauha-common`, but it does
+not yet have a synchronous `rauha sandbox` command that creates a task zone,
+runs a command, captures stdout/stderr/exit code, and cleans up. The current
+`rauha run` command starts a container in a zone and returns the container ID.
+
+## What Is a Zone?
+
+A zone is not only a namespace.
+A zone is not only a cgroup.
+
+A zone is Rauha's unit of execution, policy, isolation, observability, and
+enforcement.
+
+A zone ties together:
+
+- cgroups
+- namespaces
+- rootfs/filesystem view
+- network namespace, bridge, and rules
+- runtime metadata
+- policy
+- audit stream
+- optional kernel enforcement
+
+On macOS, the zone boundary is a lightweight VM. On Linux, the zone boundary is
+constructed from cgroups, namespaces, networking, rootfs handling, and optional
+kernel enforcement.
+
+## What Rauha Gives You
+
+- controlled agent execution
+- isolated task zones
+- structured stdout/stderr/exit-code result contracts
+- filesystem and process boundaries
+- network policy
+- resource limits
+- logs and audit events
+- future or optional Syva-backed kernel enforcement
+- Kubernetes/containerd integration as a deployment path
+
+## Current CLI
+
+The implemented CLI works at the zone and container level:
+
+```bash
+rauha zone create --name frontend --policy policies/standard.toml
+rauha image pull alpine:latest
+rauha run --zone frontend alpine:latest /bin/echo hello
+rauha ps --zone frontend
+rauha logs <container-id>
+rauha exec <container-id> -- /bin/sh
+rauha stop <container-id>
+rauha delete <container-id>
+rauha zone delete --name frontend --force
+```
+
+Use `--json` on non-streaming commands for machine-readable output.
+
+## Beyond Agents: Zone-Based Containers
+
+Rauha's agent sandbox model is built on a general zone runtime.
+
+The runtime can create zones, place containers inside those zones, apply policy,
+record metadata, expose logs, and report isolation state. This is the technical
+foundation beneath the future task-level sandbox command.
+
+Important crates:
 
 | Crate | Purpose |
-|-------|---------|
-| `rauha-common` | Shared types, `IsolationBackend` trait, policy parsing, shim IPC protocol |
-| `rauhad` | Daemon — gRPC server, zone registry, metadata (redb), networking, backends |
-| `rauha-cli` | CLI binary |
-| `rauha-shim` | Per-zone sync process — fork/run containers (Linux only) |
+| --- | --- |
+| `rauha-common` | Shared types, `IsolationBackend`, zone/container models, sandbox result types, errors, shim IPC |
+| `rauhad` | Daemon, gRPC server, zone registry, metadata, networking, Linux/macOS backends |
+| `rauha-cli` | CLI binary that talks to `rauhad` |
+| `rauha-shim` | Per-zone Linux shim that forks and runs container processes |
 | `rauha-guest-agent` | Guest-side daemon inside macOS VMs |
 | `rauha-oci` | OCI image pull, content store, rootfs preparation |
-| `rauha-ebpf` | eBPF LSM programs (kernel-side, separate build) |
-| `rauha-ebpf-common` | Shared `#[repr(C)]` types between eBPF and userspace |
-| `containerd-shim-rauha-v2` | containerd shim v2 — bridges containerd to rauhad for Kubernetes |
-| `rauha-enforce` | *Legacy.* Superseded by [Syvä](https://github.com/false-systems/syva) — a separate product. |
-| `xtask` | Build helper for eBPF compilation |
+| `containerd-shim-rauha-v2` | containerd shim v2 for Kubernetes/containerd integration |
+| `rauha-enforce` | Transitional workload discovery and zone-mapping agent for existing clusters |
+| `rauha-ebpf` | Current in-repo Linux eBPF LSM programs |
+| `rauha-ebpf-common` | Shared fixed-layout kernel/userspace types |
+| `xtask` | Build helper for eBPF and guest-agent artifacts |
 
-### Kubernetes Integration
+## Kubernetes Integration
 
-Rauha integrates with Kubernetes via a containerd shim v2. The `containerd-shim-rauha-v2` binary bridges containerd's Task ttrpc API to rauhad's gRPC API:
+Kubernetes is a deployment path, not Rauha's primary identity.
 
+The current repository includes `containerd-shim-rauha-v2`, which bridges
+containerd's Task API to `rauhad`:
+
+```text
+kubelet -> containerd -> containerd-shim-rauha-v2 -> rauhad -> Rauha zone
 ```
-kubelet → containerd → containerd-shim-rauha-v2 (ttrpc) → rauhad (gRPC)
-```
 
-Sandbox creation maps to Rauha zone creation. Container operations map to Rauha container operations within that zone. Use `runtimeClassName: rauha` in pod specs.
+The shim maps a pod sandbox to a Rauha zone and places app containers in that
+zone. This supports the same zone model under Kubernetes through RuntimeClass
+configuration once installed and wired into containerd.
 
-### Enforcement Observability
+Existing clusters can also be mapped to zones through `rauha-enforce`, which
+watches workload metadata and programs the current enforcement boundary. That
+role is discovery and zone mapping, not Rauha's product identity.
 
-Every deny decision from the 7 LSM hooks is emitted to a BPF ring buffer and streamed to userspace. Each event carries the timestamp, PID, caller zone, target zone, and hook-specific context (inode for file access, cgroup ID for cgroup escape attempts).
+## Syva-Backed Enforcement
 
-This provides:
-- **Audit trails** — provable evidence that a workload never escaped its zone
-- **Real-time visibility** — see enforcement decisions as they happen
-- **Debugging** — understand exactly why access was denied
+Rauha creates the zones. Syva makes the Linux kernel respect them.
 
-Enforcement counters (allow/deny/error per hook, per CPU) are always available for aggregate monitoring.
+Rauha owns:
 
-## Usage
+- runtime lifecycle
+- zone creation and deletion
+- sandbox/container execution
+- policy loading and validation
+- image/rootfs handling
+- networking
+- metadata
+- logs, audit, and user-facing event surfaces
+- Kubernetes/containerd integration
+
+Syva owns:
+
+- Linux kernel enforcement
+- eBPF LSM programs
+- BPF maps
+- ring buffer events
+- file/open enforcement
+- exec enforcement
+- ptrace enforcement
+- signal enforcement
+- cgroup attach enforcement
+- enforcement counters
+- kernel capability verification
+- privileged kernel self-tests
+
+Current Linux enforcement code may still live inside this repository, but
+architecturally it belongs behind the Syva enforcement boundary.
+
+## Architecture
+
+Rauha is split around the `IsolationBackend` trait in
+`rauha-common/src/backend.rs`. The daemon is platform-agnostic and delegates
+zone/container work to the active backend.
+
+Linux backend:
+
+- cgroups v2 for membership and resource grouping
+- namespaces and rootfs setup through the per-zone shim
+- network namespaces, veth pairs, bridge, and nftables
+- current in-repo eBPF LSM integration for syscall-level enforcement
+- enforcement events streamed through a BPF ring buffer and gRPC watch API
+
+macOS backend:
+
+- one lightweight Linux VM per zone through Virtualization.framework
+- virtio-vsock to the guest agent
+- virtio-fs/APFS clonefile-backed rootfs handling
+- pf anchors for network policy where available
+
+The two backends are intentionally different. Linux uses OS-level isolation
+plus optional kernel enforcement. macOS uses a VM boundary per zone.
+
+## Policy Model
+
+Policies are TOML. See `policies/standard.toml`.
+
+Policy can describe:
+
+- zone type
+- filesystem rules
+- network mode and egress
+- resource limits
+- capabilities
+- syscall policy
+- devices
+- allowed zone communication
+
+Rauha owns user-facing policy. Linux kernel-facing enforcement policy should
+eventually be translated into Syva's policy and map model behind an explicit
+boundary.
+
+## Current Status
+
+Implemented today:
+
+- zone create/list/show/delete
+- policy parse/apply/show
+- container create/start/stop/delete/list
+- image pull/list/inspect/remove
+- logs, exec, attach, trace/events surfaces
+- `IsolationBackend` abstraction
+- Linux backend with cgroups, namespaces, networking, shim orchestration, and
+  current in-repo eBPF LSM support
+- macOS VM-per-zone backend path
+- containerd shim v2 code path
+- `rauha-enforce` transitional workload discovery/zone mapping agent
+- structured sandbox result types in `rauha-common`
+- gRPC oracle suite under `eval/oracle`
+
+Planned:
+
+- `rauha sandbox` task-level CLI
+- synchronous sandbox execution API
+- structured task result emission from the daemon
+- cleanup/keep-zone behavior for task zones
+- sandbox enforcement event collection in task results
+- explicit Syva enforcer boundary
+- external Syva integration
+- Kubernetes installation docs and RuntimeClass examples
+
+Future:
+
+- move or wrap in-repo eBPF code behind Syva
+- privileged Syva/Rauha kernel enforcement test suite
+- richer agent orchestration/SDK surfaces
+- deeper workload discovery for existing clusters
+
+## Building and Testing
 
 ```bash
-# Create zones with policies
-rauha zone create --name frontend --policy policies/standard.toml
-rauha zone create --name database --policy policies/strict.toml
-
-# Run containers in zones
-rauha run --zone frontend nginx:latest
-rauha run --zone database postgres:16
-
-# Verify isolation
-rauha zone verify frontend
-
-# Image management
-rauha image pull alpine:latest
-rauha image ls
-rauha image inspect alpine:latest
-
-# Observe
-rauha ps --zone frontend
-rauha logs <container-id> --follow
-rauha exec -it <container-id> /bin/sh
-```
-
-### Zone Policies
-
-Declarative TOML. Allow-list model — nothing is permitted unless explicitly listed.
-
-```toml
-[zone]
-name = "production"
-type = "non-global"
-
-[capabilities]
-allowed = ["CAP_NET_BIND_SERVICE", "CAP_CHOWN"]
-
-[resources]
-cpu_shares = 1024
-memory_limit = "4Gi"
-pids_max = 512
-
-[network]
-mode = "bridged"
-allowed_zones = ["frontend"]
-allowed_egress = ["0.0.0.0/0:443"]
-
-[filesystem]
-writable_paths = ["/data", "/tmp", "/var/log"]
-
-[syscalls]
-deny = ["mount", "umount2", "pivot_root"]
-```
-
-## Oracle Test Suite
-
-Rauha includes a ground-truth oracle (`eval/oracle/`) — a standalone Rust binary that validates rauhad through its gRPC API. 55 numbered test cases across 11 categories. The oracle never reads source code, never mocks. When a case fails, it means the system's public contract is broken.
-
-```bash
-cd eval/oracle
-RAUHA_GRPC_ENDPOINT=http://[::1]:9876 cargo test           # all cases
-RAUHA_GRPC_ENDPOINT=http://[::1]:9876 cargo test -- case_001  # one case
-```
-
-| Range | Category | Cases |
-|-------|----------|-------|
-| 001-003 | Zone lifecycle | create, list, delete, duplicates |
-| 004-006 | Container lifecycle | create, start, stop, exit |
-| 007-009 | Image management | pull, inspect, remove |
-| 010-012 | Isolation verification | healthy, nonexistent, policy reload |
-| 013-015 | Policy enforcement | apply, memory limits, invalid rejection |
-| 016-018 | Networking | bridged, host mode, DNS |
-| 019-021 | Observability | stats, NotFound paths |
-| 022-029 | Resilience | input validation (8 cases) |
-| 030-034 | Multi-zone | coexistence, scoping, force-delete |
-| 035-039 | Container edge cases | NotFound, invalid UUID |
-| 040-054 | Invariants & stress | ID consistency, boundaries, rapid cycles |
-
-## Building
-
-```bash
-# Build all workspace crates
 cargo build
-
-# Run unit tests
 cargo test
+cargo build --bin rauhad
+cargo build --bin rauha
+cargo build --bin rauha-shim
+cargo build --bin rauha-guest-agent
+cargo build --bin rauha-enforce
+cargo build -p containerd-shim-rauha-v2
+```
 
-# Start the daemon
+Run the daemon:
+
+```bash
 RUST_LOG=rauhad=debug cargo run --bin rauhad
+```
 
-# macOS: sign after every build
-codesign --entitlements rauhad/rauhad.entitlements -s - target/debug/rauhad
+Use the CLI:
 
-# Build eBPF programs (requires nightly)
+```bash
+cargo run --bin rauha -- zone create --name test
+cargo run --bin rauha -- image pull alpine:latest
+cargo run --bin rauha -- run --zone test alpine:latest /bin/echo hello
+```
+
+Build eBPF programs:
+
+```bash
 cargo xtask build-ebpf
 ```
 
-**Linux:** kernel 6.1+, `CONFIG_BPF_LSM=y`, `CONFIG_BPF_SYSCALL=y`, `CONFIG_DEBUG_INFO_BTF=y`, boot with `lsm=lockdown,capability,bpf`
+Oracle tests live in `eval/oracle` and require a running daemon:
 
-**macOS:** macOS 15+ (Sequoia), Apple Silicon or Intel with VT-x, `com.apple.security.virtualization` entitlement
+```bash
+cd eval/oracle
+RAUHA_GRPC_ENDPOINT=http://[::1]:9876 cargo test
+```
 
-## Trade-offs
+Linux integration tests under `tests/integration` require root and a running
+daemon. eBPF enforcement tests require a kernel with BPF LSM support.
 
-**eBPF is not a kernel primitive.** Zone identity is reconstructed via BPF map lookup on every enforcement call. Defended by the `zone_cgroup_lock` LSM hook, but it's defense-in-depth, not a hardware boundary.
+## Trade-Offs
 
-**LSM is additive-only.** eBPF LSM programs can deny access but cannot override SELinux/AppArmor denials. Zone policy must be a subset of existing MAC policy.
-
-**Struct offsets are resolved at load time.** eBPF programs read kernel struct fields (e.g., `file->f_inode`, `task_struct->cgroups`) via configurable offsets injected as globals by userspace. When `pahole` is available, real offsets are read from the running kernel's BTF and patched into the programs before loading — no rebuild needed for different kernels. A runtime self-test validates the offset chain on first execution. If pahole is not installed, sensible defaults for Linux 6.1+ are used.
-
-**Covert channels** via shared kernel resources (CPU cache timing, memory pressure) are not addressable by eBPF. Same limitation as all OS-level isolation.
-
-**IPv4-focused networking.** Zone networking uses the `10.89.0.0/16` subnet. IPv6 addresses and routes are not configured for zones, and IPv6-specific egress allow-listing / NAT are not implemented. The nftables `inet` filtering rules apply to both IPv4 and IPv6, but zone network setup and IPv4-specific `ip saddr` / `ip daddr` matches mean inter-zone IPv6 networking is not supported today.
-
-## License
-
-Apache-2.0
+- eBPF LSM is OS-level isolation, not a hardware boundary.
+- macOS VM-per-zone isolation is a different model from Linux cgroups and
+  namespaces.
+- LSM is additive-only: BPF LSM can deny access but cannot override SELinux,
+  AppArmor, or other MAC denials.
+- Current Linux enforcement depends on kernel support for BPF LSM, BTF, and
+  compatible struct offsets.
+- Covert channels through shared kernel resources are out of scope.
+- Kubernetes integration requires containerd and RuntimeClass configuration.
+- The task-level `rauha sandbox` command is planned, not implemented.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,34 @@
 
 Honest documentation of what Rauha can and cannot guarantee.
 
+Rauha is an agent sandbox runtime built on controlled execution zones. It owns
+zone lifecycle, container/task execution, policy loading, metadata, networking,
+logs, and user-facing event surfaces.
+
+Rauha creates the zones. Syva makes the Linux kernel respect them.
+
+The Linux kernel enforcement code currently lives in this repository as a
+transitional implementation. Architecturally, those eBPF LSM programs, BPF
+maps, ring buffer events, counters, and kernel self-tests belong behind the
+Syva enforcement boundary. This distinction matters: Rauha is the runtime and
+zone control plane, not the kernel enforcement product.
+
 ## Isolation Models
 
-Rauha uses fundamentally different enforcement on each platform.
+Rauha exposes fundamentally different isolation models on each platform.
 They are **not equivalent** — each has different strengths and weaknesses.
 
-### Linux: Per-Syscall Software Policy (eBPF LSM)
+### Linux: Per-Syscall Software Policy (Syva/eBPF LSM)
 
-Every security-relevant syscall (file_open, kill, ptrace, exec, cgroup_attach)
-is intercepted by eBPF programs that check zone membership in BPF maps.
+On Linux, zone boundaries can be enforced by eBPF LSM programs that check
+zone membership in BPF maps on security-relevant operations such as
+file_open, exec, ptrace, signal delivery, cgroup attach, capability checks,
+and socket connect.
+
+In the current transitional codebase, `rauhad` still loads and manages these
+programs directly from `rauhad/src/backend/linux/` and `rauha-ebpf/`.
+The target architecture moves this behind Syva while keeping Rauha as the
+runtime API and event surface.
 
 **Strengths:**
 - Granular observability — every denied operation is visible
@@ -60,6 +79,11 @@ protocol as the Linux shim.
 status or interprets enforcement events **must** check this field.
 A report from Linux and macOS cannot be compared directly.
 
+Agent sandbox results should treat enforcement events as an optional stream:
+Linux/Syva-backed zones can populate them, macOS VM-backed zones may expose
+different audit information, and unsupported/degraded Linux hosts may have no
+kernel enforcement events at all.
+
 ## Known Limitations
 
 ### Shim Privilege Window (Linux, Phase 3)
@@ -71,10 +95,10 @@ necessary but creates a privilege window:
 1. Shim starts in host namespace with elevated privileges
 2. Shim creates zone namespace infrastructure
 3. Shim forks container process into zone
-4. eBPF enforcement is fully active
+4. Syva/eBPF enforcement is fully active
 
 Between steps 1-3, a compromised shim can manipulate zone setup before
-eBPF enforcement is in place. Mitigations planned:
+kernel enforcement is in place. Mitigations planned:
 - Minimize shim capabilities to only what's needed for setup
 - Drop privileges immediately after namespace setup
 - Validate zone state before marking it Ready (verify_isolation check)
@@ -95,34 +119,35 @@ This is a known hard problem. containerd and gVisor both learned this:
 - containerd uses pid namespaces (structural) + procfs masking (defense-in-depth)
 - gVisor reimplements procfs entirely (expensive, complete)
 
-Rauha's approach: pid namespaces provide the structural isolation, eBPF
-proc filtering is defense-in-depth. We document it as such, not as primary
-enforcement.
+Rauha's approach: pid namespaces provide the structural isolation, and
+Syva/eBPF proc filtering is defense-in-depth. We document it as such, not as
+primary isolation.
 
-### BPF Map / Metadata Consistency (Linux)
+### Kernel Enforcement / Metadata Consistency (Linux)
 
-BPF maps (in-kernel enforcement state) and redb (persisted policy) are
-separate stores. If rauhad crashes between updating one and the other,
-they can diverge.
+BPF maps (current in-kernel enforcement state) and redb (Rauha's persisted
+zone/policy metadata) are separate stores. If rauhad crashes between updating
+one and the other, they can diverge.
 
 **Recovery:** On startup, rauhad reconciles by treating redb as the source
-of truth. It re-pushes all zone policies to BPF maps, re-creates missing
-cgroups and network namespaces, and cleans up orphaned kernel state.
+of truth. It re-pushes all zone policies to the current kernel enforcement
+boundary, re-creates missing cgroups and network namespaces, and cleans up
+orphaned kernel state.
 See `ZoneRegistry::reconcile()`.
 
 **Remaining gap:** During the window between rauhad crash and restart,
-stale BPF maps continue enforcing the old policy. This is acceptable
+stale kernel enforcement maps continue enforcing the old policy. This is acceptable
 because stale policy is either correct (crash happened before redb write)
 or more restrictive than intended (crash happened after redb write but
-before BPF update relaxed a policy). Policy updates are never less
+before the kernel-enforcement update relaxed a policy). Policy updates are never less
 restrictive during this window.
 
 ### ptrace and signal Guards (Linux)
 
-The ptrace_access_check and task_kill eBPF guards are incomplete. They
-can identify the calling process's zone but cannot reliably determine the
-target process's zone without CO-RE BTF support for cross-kernel
-`task_struct` field access.
+The ptrace_access_check and task_kill guards in the current in-repo eBPF
+implementation are incomplete. They can identify the calling process's zone
+but cannot reliably determine the target process's zone without CO-RE BTF
+support for cross-kernel `task_struct` field access.
 
 Current state: these guards check if the caller is in a zone with ptrace
 allowed, but do not verify the target is in the same zone. Full cross-zone
@@ -146,9 +171,11 @@ daemon crash — there is no way to reattach to a VM that was destroyed.
 
 ### Kernel Version Sensitivity (Linux)
 
-eBPF programs use hardcoded struct offsets (e.g., `struct file->f_inode`
-at offset 32). These are correct for Linux 6.1+ but may break on future
-kernels that change struct layouts.
+The current in-repo eBPF programs use hardcoded struct offsets (e.g.,
+`struct file->f_inode` at offset 32). These are correct for Linux 6.1+ but
+may break on future kernels that change struct layouts.
 
 Fix: migrate to CO-RE (Compile Once, Run Everywhere) using BTF-based
-field access. Aya supports this but it adds build complexity.
+field access. Aya supports this but it adds build complexity. Longer-term,
+this kernel compatibility work belongs in Syva, with Rauha consuming the
+result through an enforcement boundary.

--- a/docs/rauha-syva-boundary.md
+++ b/docs/rauha-syva-boundary.md
@@ -1,0 +1,82 @@
+# Rauha and Syva Boundary
+
+Rauha creates the zones. Syva makes the Linux kernel respect them.
+
+This boundary keeps Rauha from becoming "the eBPF project" and keeps Syva from
+becoming a runtime.
+
+## Rauha Owns
+
+- agent sandbox execution
+- zone lifecycle
+- container lifecycle
+- daemon, CLI, and API
+- policy loading and validation
+- image/rootfs handling
+- networking
+- metadata
+- logs and audit events
+- Kubernetes/containerd integration
+- macOS VM-per-zone backend
+- user-facing enforcement event surfaces
+
+## Syva Owns
+
+- Linux kernel enforcement
+- eBPF LSM programs
+- BPF maps
+- ring buffer events
+- file/open enforcement
+- exec enforcement
+- ptrace enforcement
+- signal enforcement
+- cgroup attach enforcement
+- enforcement counters
+- kernel capability verification
+- privileged kernel self-tests
+
+## Current Transitional State
+
+The Rauha repository still contains Linux eBPF code:
+
+- `rauha-ebpf`
+- `rauha-ebpf-common`
+- `rauhad/src/backend/linux/ebpf.rs`
+- `rauhad/src/backend/linux/maps.rs`
+- `rauhad/src/backend/linux/events.rs`
+- `rauha-enforce`
+
+That code is still useful, but architecturally it should sit behind a Syva
+enforcement boundary.
+
+## Future Seam
+
+A future implementation should introduce a small kernel-enforcement interface
+behind Rauha's zone lifecycle. Conceptually:
+
+```rust
+trait KernelEnforcer {
+    fn load(&self) -> Result<()>;
+    fn create_zone(&self, spec: ZoneKernelSpec) -> Result<()>;
+    fn delete_zone(&self, zone_id: ZoneId) -> Result<()>;
+    fn apply_policy(&self, zone_id: ZoneId, policy: KernelZonePolicy) -> Result<()>;
+    fn watch_events(&self) -> EnforcementEventStream;
+    fn stats(&self) -> Result<EnforcementStats>;
+    fn verify(&self) -> Result<KernelEnforcementReport>;
+}
+```
+
+This is a design sketch, not a committed API.
+
+The important rules are:
+
+- Rauha owns user-facing runtime lifecycle.
+- Rauha owns user-facing policy.
+- Syva owns Linux kernel enforcement.
+- Rauha translates Rauha policy into Syva/kernel-facing policy.
+- Rauha exposes Syva events through Rauha APIs and sandbox results.
+- macOS does not use Syva.
+- unsupported platforms should use an explicit Noop/Unsupported enforcer.
+
+Do not delete the current eBPF crates until an external Syva integration exists
+and tests prove the replacement path.

--- a/docs/sandbox-runtime.md
+++ b/docs/sandbox-runtime.md
@@ -1,0 +1,66 @@
+# Rauha Sandbox Runtime
+
+Rauha's primary product shape is an agent sandbox runtime.
+
+The target command is:
+
+```bash
+rauha sandbox --image python:3.12 --repo . -- pytest tests/
+```
+
+This is not implemented yet. The current repository can create zones and start
+containers, but `rauha run` is asynchronous container lifecycle:
+
+1. create a container in an existing zone
+2. start it
+3. return the container ID
+
+It does not currently:
+
+- allocate a temporary task zone
+- wait for command completion
+- capture stdout and stderr into a single result
+- record duration
+- return exit code from the initial process
+- collect task-scoped enforcement events
+- clean up the temporary zone by default
+
+## Result Contract
+
+`rauha-common/src/sandbox.rs` defines the portable result shape for future
+sandbox execution:
+
+```json
+{
+  "task_id": "task_123",
+  "zone_id": "zone_456",
+  "command": ["pytest", "tests/"],
+  "status": "succeeded",
+  "exit_code": 0,
+  "stdout": "...",
+  "stderr": "",
+  "duration_ms": 1842,
+  "started_at": null,
+  "finished_at": null,
+  "events": [],
+  "enforcement_events": []
+}
+```
+
+`enforcement_events` may be empty. That is the expected portable baseline.
+When Syva integration is added, Linux kernel events can populate that field
+without changing the user-facing result contract.
+
+## Minimal Implementation Plan
+
+1. Add a daemon RPC for task-level sandbox execution.
+2. Create or select a zone for the task.
+3. Create/start a container or process inside the zone.
+4. Wait for completion.
+5. Capture stdout, stderr, exit code, and duration.
+6. Collect audit and enforcement event summaries.
+7. Clean up by default, with an explicit keep/debug option.
+8. Add `rauha sandbox` CLI with `--json`.
+
+The first implementation should wrap existing zone/container primitives rather
+than bypassing them with an ordinary host `std::process::Command`.

--- a/rauha-cli/src/main.rs
+++ b/rauha-cli/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand};
 use commands::output::OutputMode;
 
 #[derive(Parser)]
-#[command(name = "rauha", version, about = "Zones-like container runtime")]
+#[command(name = "rauha", version, about = "Agent sandbox runtime built on controlled execution zones")]
 struct Cli {
     /// Output JSON instead of human-readable text
     #[arg(long, global = true)]

--- a/rauha-common/Cargo.toml
+++ b/rauha-common/Cargo.toml
@@ -13,3 +13,6 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 postcard = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+serde_json = "1"

--- a/rauha-common/src/backend.rs
+++ b/rauha-common/src/backend.rs
@@ -5,9 +5,11 @@ use crate::zone::{IsolationModel, IsolationReport, ZoneConfig, ZoneHandle, ZoneP
 
 /// The core abstraction for platform-specific isolation.
 ///
-/// Both Linux (eBPF + namespaces) and macOS (Virtualization.framework + sandbox)
-/// backends implement this trait. `rauhad` uses `dyn IsolationBackend` to remain
-/// platform-agnostic.
+/// Linux and macOS backends implement this trait. `rauhad` uses
+/// `dyn IsolationBackend` to remain platform-agnostic while Rauha keeps
+/// ownership of user-facing zone lifecycle. Linux kernel enforcement currently
+/// lives in this repository, but the architectural boundary is Syva-backed:
+/// Rauha creates zones; Syva makes the Linux kernel respect them.
 pub trait IsolationBackend: Send + Sync {
     /// Create a new isolation zone.
     fn create_zone(&self, config: &ZoneConfig) -> Result<ZoneHandle>;

--- a/rauha-common/src/lib.rs
+++ b/rauha-common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod backend;
 pub mod container;
 pub mod error;
+pub mod sandbox;
 pub mod shim;
 pub mod zone;

--- a/rauha-common/src/sandbox.rs
+++ b/rauha-common/src/sandbox.rs
@@ -1,0 +1,137 @@
+//! Structured results for agent sandbox execution.
+//!
+//! Rauha's sandbox command is planned as a task-level wrapper around zones:
+//! create or select a zone, run one command, collect outputs and events, then
+//! clean up according to policy. The runtime path is not implemented here yet,
+//! but this module defines the stable result shape that CLI/API surfaces can
+//! use without depending on the future Linux Syva integration.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Result of one sandboxed task execution.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxExecResult {
+    pub task_id: String,
+    pub zone_id: String,
+    pub command: Vec<String>,
+    pub status: SandboxStatus,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub duration_ms: u64,
+    pub started_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub events: Vec<SandboxEventSummary>,
+    pub enforcement_events: Vec<EnforcementEventSummary>,
+}
+
+impl SandboxExecResult {
+    /// Build an empty runtime-error result for command paths that cannot start.
+    pub fn runtime_error(
+        task_id: impl Into<String>,
+        zone_id: impl Into<String>,
+        command: Vec<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            task_id: task_id.into(),
+            zone_id: zone_id.into(),
+            command,
+            status: SandboxStatus::RuntimeError,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: message.into(),
+            duration_ms: 0,
+            started_at: None,
+            finished_at: None,
+            events: Vec::new(),
+            enforcement_events: Vec::new(),
+        }
+    }
+}
+
+/// High-level outcome of one sandboxed task.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxStatus {
+    Succeeded,
+    Failed,
+    TimedOut,
+    RuntimeError,
+}
+
+/// Small user-facing event summary attached to a sandbox result.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxEventSummary {
+    pub timestamp: Option<DateTime<Utc>>,
+    pub kind: String,
+    pub message: String,
+}
+
+/// Kernel enforcement event summary attached to a sandbox result.
+///
+/// This intentionally does not expose raw BPF map/ring-buffer structures.
+/// Rauha owns the user-facing runtime result; Syva can later populate these
+/// summaries from Linux kernel enforcement events.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnforcementEventSummary {
+    pub timestamp: Option<DateTime<Utc>>,
+    pub hook: String,
+    pub action: String,
+    pub decision: String,
+    pub message: String,
+    pub pid: Option<u32>,
+    pub source_zone: Option<String>,
+    pub target_zone: Option<String>,
+    pub object: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_status_serializes_as_snake_case() {
+        let value = serde_json::to_value(SandboxStatus::RuntimeError).unwrap();
+        assert_eq!(value, serde_json::json!("runtime_error"));
+    }
+
+    #[test]
+    fn sandbox_result_serializes_with_empty_enforcement_events() {
+        let result = SandboxExecResult {
+            task_id: "task-1".into(),
+            zone_id: "zone-1".into(),
+            command: vec!["echo".into(), "hello".into()],
+            status: SandboxStatus::Succeeded,
+            exit_code: Some(0),
+            stdout: "hello\n".into(),
+            stderr: String::new(),
+            duration_ms: 12,
+            started_at: None,
+            finished_at: None,
+            events: Vec::new(),
+            enforcement_events: Vec::new(),
+        };
+
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(value["status"], "succeeded");
+        assert_eq!(value["enforcement_events"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn runtime_error_result_has_no_exit_code_or_events() {
+        let result = SandboxExecResult::runtime_error(
+            "task-1",
+            "zone-1",
+            vec!["pytest".into()],
+            "sandbox runtime is not available",
+        );
+
+        assert_eq!(result.status, SandboxStatus::RuntimeError);
+        assert_eq!(result.exit_code, None);
+        assert_eq!(result.stderr, "sandbox runtime is not available");
+        assert!(result.events.is_empty());
+        assert!(result.enforcement_events.is_empty());
+    }
+}

--- a/rauha-enforce/src/main.rs
+++ b/rauha-enforce/src/main.rs
@@ -1,8 +1,9 @@
-//! rauha-enforce — standalone eBPF enforcement agent.
+//! rauha-enforce — workload discovery and zone-mapping agent.
 //!
-//! Drops kernel-level zone enforcement onto existing containerd/Docker clusters.
-//! No runtime replacement needed. Watches container events, maps workloads to
-//! zones by label, and populates BPF maps.
+//! Watches existing containerd/Docker workloads, maps them to Rauha zones, and
+//! programs the current kernel enforcement boundary. Architecturally, that
+//! boundary belongs to Syva: Rauha creates zones, Syva makes the Linux kernel
+//! respect them.
 //!
 //! Usage:
 //!   rauha-enforce --policy-dir /etc/rauha/policies/
@@ -24,7 +25,7 @@ use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
-#[command(name = "rauha-enforce", about = "eBPF enforcement agent for container isolation")]
+#[command(name = "rauha-enforce", about = "Map existing workloads to Rauha zones")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -218,7 +219,7 @@ fn print_status_summary(
         .collect();
 
     tracing::info!(
-        programs = "5/5",
+        programs = "7/7",
         zones = zone_names.len(),
         containers_enforced = enforced,
         "enforcement active"

--- a/rauhad/src/backend/linux/events.rs
+++ b/rauhad/src/backend/linux/events.rs
@@ -1,6 +1,6 @@
 //! Enforcement event reader — drains the BPF ring buffer in a background task.
 //!
-//! Deny events from all 5 LSM hooks are streamed here, logged via tracing,
+//! Deny events from all 7 LSM hooks are streamed here, logged via tracing,
 //! and broadcast to any gRPC WatchEvents subscribers.
 
 use std::time::Duration;

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -1,9 +1,12 @@
-//! Linux isolation backend: eBPF LSM + cgroups v2 + network namespaces.
+//! Linux isolation backend: cgroups v2 + namespaces + current eBPF LSM support.
 //!
-//! Orchestrates three subsystems:
-//! - eBPF LSM programs enforce zone boundaries at the syscall level
+//! Orchestrates the Linux pieces behind Rauha zones:
 //! - cgroup v2 hierarchy provides resource limits and process grouping
 //! - Network namespaces + veth pairs isolate network stacks
+//! - current in-repo eBPF LSM programs enforce zone boundaries at syscall level
+//!
+//! Architecturally, the kernel enforcement piece belongs behind the Syva
+//! boundary: Rauha creates zones; Syva makes the Linux kernel respect them.
 
 mod cgroup;
 mod ebpf;


### PR DESCRIPTION
## Summary

Reposition Rauha around the load-bearing product hierarchy now that Syvä has been extracted as a separate False Systems product:

1. **Agent sandbox runtime** — the headline
2. **Zone-based runtime foundation** — the technical credibility layer
3. **Kubernetes/containerd and existing-workload deployment paths**
4. **Syvä-backed Linux kernel enforcement** — a future seam, not Rauha's identity

No behavior change. Pure docs + the public-facing result type for the planned `rauha sandbox` command.

## What's in this PR

**`feat(rauha-common): add SandboxExecResult types`** — the stable result shape for the planned `rauha sandbox` task-level runtime: `SandboxExecResult`, `SandboxStatus` (snake_case JSON), `SandboxEventSummary`, `EnforcementEventSummary`. The runtime path is *not* implemented here; only the user-facing contract. `EnforcementEventSummary` is intentionally abstract over BPF map / ring buffer specifics so future Syvä events can populate it without leaking kernel-side types.

**`docs: reposition Rauha around agent sandbox runtime`**:
- `README.md` rewritten around the four-layer hierarchy above. `rauha sandbox` example is explicitly marked "intended task-level user experience," not implemented.
- `CLAUDE.md` opens with the new hierarchy so future contributors lead with the right framing.
- `docs/sandbox-runtime.md` and `docs/rauha-syva-boundary.md` hold the longer-form explanations.
- Module-level docs updated for the framing: `rauha-common::backend`, `rauhad::backend::linux::mod`, `rauha-enforce` (now "workload discovery and zone-mapping agent," not "the enforcement engine").
- CLI `about` strings updated.

**Stale-fact fixes that ride along** (same drift class fixed in #35's `cae3af7`):
- `rauhad/src/backend/linux/events.rs` doc comment: "5 LSM hooks" → "7"
- `rauha-enforce` status output: `programs = "5/5"` → `"7/7"`

## What's *not* in this PR

- `rauha sandbox` CLI command — the runtime path requires synchronous task execution that doesn't exist yet (rauhad's `ExecInContainer` is unimplemented in `server.rs`). Documented as planned, not faked.
- `KernelEnforcer` trait / Syvä client integration — explicitly deferred. The architectural seam is documented; the code seam is the next phase.
- Any deletion of `rauha-ebpf` / `rauha-ebpf-common` — they stay in-repo until the Syvä integration is proven, per the migration plan in `docs/rauha-syva-boundary.md`.

## Test plan

- [x] `cargo test -p rauha-common` — 12 passed (3 new tests for sandbox result types: snake_case status, empty enforcement_events default, runtime_error builder)
- [x] `cargo test --workspace --exclude rauha-enforce --exclude rauha-ebpf-common` — passes on macOS host (rauha-enforce excluded due to pre-existing aya/Linux-only dep issues, unrelated to this PR)
- [x] `git diff --check` — clean

## Next PRs

1. **Add daemon-level sandbox execution RPC** — wires `ExecInContainer` to a real synchronous code path that produces `SandboxExecResult`.
2. **Add `rauha sandbox <task> --json`** — CLI wrapper around that RPC.
3. **Introduce `KernelEnforcer` trait behind Linux backend** — Phase 1 of the Syvä integration (see `CODEX_PROMPT.md` draft, untracked).
4. **`SyvaEnforcer` impl** — connect rauhad to the syva-core daemon via `syva-core-client`.
5. **Externalize / wrap rauha-ebpf** — once Syvä replacement is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)