### PR TITLE
feat(shim): expose container exit code in state response

### DIFF
--- a/rauha-common/src/shim.rs
+++ b/rauha-common/src/shim.rs
@@ -53,7 +53,11 @@ pub enum ShimRequest {
 pub enum ShimResponse {
     Ok,
     Created { pid: u32 },
-    State { pid: u32, status: String },
+    State {
+        pid: u32,
+        status: String,
+        exit_code: Option<i32>,
+    },
     Error { message: String },
     /// Zone-level resource usage statistics.
     Stats {
@@ -212,6 +216,12 @@ mod tests {
             ShimResponse::State {
                 pid: 999,
                 status: "running".into(),
+                exit_code: None,
+            },
+            ShimResponse::State {
+                pid: 999,
+                status: "stopped".into(),
+                exit_code: Some(42),
             },
             ShimResponse::Error {
                 message: "something failed".into(),

--- a/rauha-guest-agent/src/main.rs
+++ b/rauha-guest-agent/src/main.rs
@@ -25,6 +25,7 @@ struct AgentState {
 struct ContainerProcess {
     pid: u32,
     status: ContainerStatus,
+    exit_code: Option<i32>,
     spec_json: String,
 }
 
@@ -53,6 +54,7 @@ impl AgentState {
             ContainerProcess {
                 pid: 0,
                 status: ContainerStatus::Created,
+                exit_code: None,
                 spec_json: spec_json.to_string(),
             },
         );
@@ -89,14 +91,14 @@ impl AgentState {
         container::send_signal(proc.pid, signal).map_err(|e| e.to_string())
     }
 
-    fn get_state(&self, id: &str) -> Option<(u32, String)> {
+    fn get_state(&self, id: &str) -> Option<(u32, String, Option<i32>)> {
         self.containers.get(id).map(|p| {
             let status = match p.status {
                 ContainerStatus::Created => "created",
                 ContainerStatus::Running => "running",
                 ContainerStatus::Stopped => "stopped",
             };
-            (p.pid, status.to_string())
+            (p.pid, status.to_string(), p.exit_code)
         })
     }
 
@@ -105,8 +107,9 @@ impl AgentState {
             if proc.status != ContainerStatus::Running || proc.pid == 0 {
                 continue;
             }
-            if let Some(_exit_code) = container::try_wait(proc.pid) {
+            if let Some(exit_code) = container::try_wait(proc.pid) {
                 proc.status = ContainerStatus::Stopped;
+                proc.exit_code = Some(exit_code);
             }
         }
     }
@@ -137,7 +140,11 @@ fn handle_request(state: &mut AgentState, request: ShimRequest) -> ShimResponse 
             }
         }
         ShimRequest::GetState { id } => match state.get_state(&id) {
-            Some((pid, status)) => ShimResponse::State { pid, status },
+            Some((pid, status, exit_code)) => ShimResponse::State {
+                pid,
+                status,
+                exit_code,
+            },
             None => ShimResponse::Error {
                 message: format!("container {id} not found"),
             },
@@ -173,8 +180,8 @@ fn handle_request(state: &mut AgentState, request: ShimRequest) -> ShimResponse 
 
             // Verify container exists and is running.
             match state.get_state(&id) {
-                Some((_pid, status)) if status == "running" => {}
-                Some((_, status)) => {
+                Some((_pid, status, _exit_code)) if status == "running" => {}
+                Some((_, status, _)) => {
                     return ShimResponse::Error {
                         message: format!("container {id} is in {status} state, not running"),
                     };

--- a/rauha-shim/src/main.rs
+++ b/rauha-shim/src/main.rs
@@ -133,7 +133,11 @@ fn handle_request(state: &mut ShimState, request: ShimRequest) -> ShimResponse {
             },
         },
         ShimRequest::GetState { id } => match state.get_state(&id) {
-            Some((pid, status)) => ShimResponse::State { pid, status },
+            Some((pid, status, exit_code)) => ShimResponse::State {
+                pid,
+                status,
+                exit_code,
+            },
             None => ShimResponse::Error {
                 message: format!("container {id} not found"),
             },

--- a/rauha-shim/src/state.rs
+++ b/rauha-shim/src/state.rs
@@ -118,10 +118,10 @@ impl ShimState {
     }
 
     /// Get the state of a container.
-    pub fn get_state(&self, id: &str) -> Option<(u32, String)> {
+    pub fn get_state(&self, id: &str) -> Option<(u32, String, Option<i32>)> {
         self.containers
             .get(id)
-            .map(|p| (p.pid, p.status.to_string()))
+            .map(|p| (p.pid, p.status.to_string(), p.exit_code))
     }
 
     /// Reap exited child processes.

--- a/rauhad/src/zone/registry.rs
+++ b/rauhad/src/zone/registry.rs
@@ -428,6 +428,52 @@ impl ZoneRegistry {
         Ok(())
     }
 
+    /// Query the zone shim for container state and persist stopped metadata.
+    #[allow(dead_code)] // Used by sandbox wait support in the next PR.
+    pub async fn get_container_state(&self, container_id: &Uuid) -> Result<(String, Option<i32>)> {
+        let container = self
+            .metadata
+            .get_container(container_id)?
+            .ok_or_else(|| RauhaError::ContainerNotFound(*container_id))?;
+
+        let zone_name = self
+            .zone_name_for_container(&container.zone_id)
+            .await
+            .ok_or_else(|| RauhaError::ZoneNotFound(container.zone_id.to_string()))?;
+
+        let response = self
+            .shim_request(
+                &zone_name,
+                &rauha_common::shim::ShimRequest::GetState {
+                    id: container_id.to_string(),
+                },
+            )
+            .await?;
+
+        match response {
+            rauha_common::shim::ShimResponse::State {
+                status, exit_code, ..
+            } => {
+                if status == "stopped" {
+                    let mut updated = container;
+                    updated.state = ContainerState::Stopped;
+                    updated.finished_at.get_or_insert_with(Utc::now);
+                    updated.exit_code = exit_code;
+                    self.metadata.put_container(&updated)?;
+                }
+                Ok((status, exit_code))
+            }
+            rauha_common::shim::ShimResponse::Error { message } => Err(RauhaError::ShimError {
+                zone: zone_name,
+                message,
+            }),
+            other => Err(RauhaError::ShimError {
+                zone: zone_name,
+                message: format!("unexpected shim response to GetState: {other:?}"),
+            }),
+        }
+    }
+
     /// Delete a container, stopping it first if needed.
     pub async fn delete_container(&self, container_id: &Uuid, force: bool) -> Result<()> {
         let container = self

--- a/rauhad/src/zone/registry.rs
+++ b/rauhad/src/zone/registry.rs
@@ -454,12 +454,20 @@ impl ZoneRegistry {
             rauha_common::shim::ShimResponse::State {
                 status, exit_code, ..
             } => {
-                if status == "stopped" {
+                if status == "stopped"
+                    && (container.state != ContainerState::Stopped
+                        || container.exit_code != exit_code)
+                {
                     let mut updated = container;
                     updated.state = ContainerState::Stopped;
                     updated.finished_at.get_or_insert_with(Utc::now);
                     updated.exit_code = exit_code;
                     self.metadata.put_container(&updated)?;
+                    tracing::info!(
+                        container = %container_id,
+                        exit_code = ?exit_code,
+                        "container exit captured"
+                    );
                 }
                 Ok((status, exit_code))
             }


### PR DESCRIPTION
## Summary

PR A for the sandbox runtime sequence.

- Adds `exit_code: Option<i32>` to internal postcard `ShimResponse::State`.
- Populates the field from the Linux shim and macOS guest-agent reap state.
- Adds `ZoneRegistry::get_container_state`, which queries the zone shim and persists `exit_code` when a container reaches `stopped`.

Behavior change: none for existing flows; `ShimResponse::State` gains an `exit_code` field. The shim and daemon are built and shipped together, so no wire-skew is expected — stale shim binaries on disk must be rebuilt. The IPC is internal postcard, not protobuf, so no external clients are affected.

## Verification

- `cargo test -p rauha-common` — passed, 12 tests
- `cargo test -p rauha-shim` — passed, 0 tests, existing warnings only
- `cargo test -p rauha-guest-agent` — passed, 0 tests, existing warning only
- `cargo test -p rauhad` — passed, 45 tests, existing warnings only
- `git diff --check` — passed
- `cargo build --workspace --exclude rauha-enforce` — passed with existing warnings

`cargo build --workspace` was also run on this macOS host and fails in the pre-existing Linux-only `rauha-enforce`/`aya` path with missing Linux netlink/BPF libc symbols (`AF_NETLINK`, `SYS_bpf`, `CLOCK_BOOTTIME`, etc.). That is unrelated to this PR; the non-enforcement workspace build passes.