### PR TITLE
Fail-closed Linux enforcement, evidence observability, policy hardening (+ Syvä-style README)

### DIFF
--- a/BASELINE.md
+++ b/BASELINE.md
@@ -1,0 +1,199 @@
+# Rauha Baseline
+
+Captured: 2026-06-14
+
+Host/control machine: macOS (`aarch64-apple-darwin`), using Lima instance `ubuntu` for Linux measurements.
+
+Linux measurement environment:
+- `rustc 1.95.0 (59807616e 2026-04-14)`
+- host triple: `aarch64-unknown-linux-gnu`
+- `cargo-bloat 0.12.1`
+- target dir: `$HOME/rauha-target-baseline` inside the Lima guest
+- build prerequisites installed in the guest during baseline capture: `pkg-config`, `libssl-dev`, `protobuf-compiler`
+
+## Binary Sizes
+
+Command:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-baseline cargo build --release --bins
+```
+
+Stripped sizes were measured by copying each binary and running `strip` on the copy.
+
+| Binary | Unstripped bytes | Stripped bytes |
+| --- | ---: | ---: |
+| `rauhad` | 11,767,264 | 8,275,768 |
+| `rauha` | 6,981,464 | 4,929,224 |
+| `rauha-shim` | 4,717,488 | 3,349,200 |
+| `rauha-guest-agent` | 4,188,632 | 2,955,840 |
+| `rauha-enforce` | 6,972,720 | 4,798,792 |
+| `containerd-shim-rauha-v2` | 8,488,960 | 5,845,816 |
+
+## Dependency Weight
+
+Command:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-baseline cargo bloat --release --crates --bin rauhad -n 25
+```
+
+Top `rauhad` `.text` contributors:
+
+| Crate | Size |
+| --- | ---: |
+| `std` | 1019.8 KiB |
+| `redb` | 430.7 KiB |
+| `reqwest` | 425.2 KiB |
+| `rauhad` | 420.8 KiB |
+| `tokio` | 245.0 KiB |
+| `h2` | 229.0 KiB |
+| `tonic` | 205.5 KiB |
+| `aya_obj` | 175.2 KiB |
+| `regex_syntax` | 171.3 KiB |
+| `toml_edit` | 161.5 KiB |
+
+`rauhad` total `.text`: 4.9 MiB. File size reported by `cargo bloat`: 15.0 MiB.
+
+Command:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-baseline cargo bloat --release --crates --bin containerd-shim-rauha-v2 -n 25
+```
+
+Top `containerd-shim-rauha-v2` `.text` contributors:
+
+| Crate | Size |
+| --- | ---: |
+| `std` | 814.3 KiB |
+| `regex_automata` | 381.0 KiB |
+| `tokio` | 286.4 KiB |
+| `h2` | 224.5 KiB |
+| `serde_json` | 218.3 KiB |
+| `ttrpc` | 203.8 KiB |
+| `regex_syntax` | 185.9 KiB |
+| `cgroups_rs` | 146.6 KiB |
+| `tonic` | 133.5 KiB |
+| `containerd_shim` | 126.3 KiB |
+
+`containerd-shim-rauha-v2` total `.text`: 3.3 MiB. File size reported by `cargo bloat`: 11.8 MiB.
+
+### Duplicate Dependencies
+
+Command:
+
+```sh
+cargo tree --duplicates
+```
+
+Notable duplicate/multiple-version stacks:
+
+- `nix`: `0.24.3`, `0.25.1`, `0.26.4`, `0.29.0`
+- `prost`: `0.8.0`, `0.13.5`
+- `prost-build`: `0.8.0`, `0.13.5`
+- `prost-types`: `0.8.0`, `0.13.5`
+- `tower`: `0.4.13`, `0.5.3`
+- `rustix`: `0.38.44`, `1.1.4`
+- `bitflags`: `1.3.2`, `2.11.0`
+- `indexmap`: `1.9.3`, `2.13.0`
+- `hashbrown`: `0.12.3`, `0.15.5`, `0.16.1`
+- `syn`: `1.0.109`, `2.0.117`
+
+`containerd-shim`, `containerd-shim-protos`, `ttrpc`, and `containerd-client` pull several older protobuf/TTRPC-era versions.
+
+### Tokio/Tonic/Prost Features
+
+Current workspace dependency:
+
+```toml
+tokio = { version = "1", features = ["full"] }
+tonic = "0.12"
+prost = "0.13"
+```
+
+`cargo tree -e features -i tokio` confirms `tokio/full` is enabled by workspace crates including `rauhad`, `rauha-cli`, `rauha-oci`, `rauha-enforce`, and `containerd-shim-rauha-v2`.
+
+`cargo tree -e features -i tonic` confirms default `tonic` features, including `transport`, `channel`, `server`, `router`, `prost`, and `codegen`.
+
+`cargo tree -e features -i prost` is ambiguous because both `prost@0.8.0` and `prost@0.13.5` are present.
+
+## Cold-Path Latency
+
+Criterion benches added in `rauha-common/benches/cold_path.rs`.
+
+Command:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-baseline cargo bench -p rauha-common --bench cold_path -- --sample-size 50
+```
+
+| Benchmark | Mean range |
+| --- | ---: |
+| `policy_parse_validate` | 7.8736 us - 7.9079 us |
+| `zone_object_construction` | 121.10 ns - 122.33 ns |
+
+Not yet measured in this baseline:
+
+- OCI rootfs prep: needs a dedicated fixture that avoids pulling from the network and avoids privileged overlay assumptions.
+- gRPC request round-trip on a no-op call: needs a daemon test harness with an unprivileged no-op/negative request path.
+
+## Panic/Abort Surface
+
+Command:
+
+```sh
+rg -n 'unwrap\(|expect\(|panic!\(|unreachable!' <crate> -g '*.rs' | wc -l
+```
+
+| Crate | Count |
+| --- | ---: |
+| `rauha-common` | 28 |
+| `rauhad` | 151 |
+| `rauha-cli` | 5 |
+| `rauha-shim` | 5 |
+| `rauha-guest-agent` | 6 |
+| `rauha-oci` | 150 |
+| `rauha-enforce` | 0 |
+| `containerd-shim-rauha-v2` | 0 |
+| `rauha-ebpf-common` | 0 |
+| `rauha-ebpf` | 0 |
+
+Initial request/enforcement-path candidates observed in the raw grep:
+
+- `rauha-shim/src/container.rs` and `rauha-shim/src/attach.rs`: `CString::new(...).unwrap()` on process args/env.
+- `rauha-shim/src/state.rs`: mutable container lookup with `unwrap()`.
+- `rauha-guest-agent/src/container.rs`, `attach.rs`, and `main.rs`: `CString::new(...).unwrap()` and container lookup with `unwrap()`.
+- `rauhad/src/main.rs`: content-store initialization uses `expect(...)`.
+- `rauhad/src/backend/macos/vm.rs`: several mutex/result `unwrap()` calls on the macOS backend path.
+- `rauha-oci/src/image.rs`: extraction mutex `unwrap()` on runtime path.
+
+Many other hits are test-only assertions and should be separated before enforcing a no-panic runtime policy.
+
+## eBPF Crates
+
+- `rauha-ebpf/src/main.rs` has `#![no_std]` and `#![no_main]`.
+- `rauha-ebpf/Cargo.toml` sets `panic = "abort"` for dev and release.
+- `rauha-ebpf-common/src/lib.rs` uses `#![cfg_attr(not(feature = "userspace"), no_std)]`.
+- `rauha-ebpf-common` only enables `aya` for the `userspace` feature.
+
+## Verification Status
+
+Measured/compiled/passed:
+
+- Linux release workspace binaries compile in Lima with `cargo build --release --bins`.
+- Linux workspace tests pass in Lima with `cargo test --workspace`.
+- Linux workspace build passes in Lima with `cargo build --workspace`.
+- Linux clippy exits successfully in Lima with `cargo clippy --workspace --all-targets`; existing warnings remain.
+- macOS `rauhad` backend compile-check passes on the host with `cargo check -p rauhad`; existing warnings remain.
+- Native macOS all-binaries build was attempted on the host and failed because `rauha-enforce` depends on Linux-only `aya` symbols when built on macOS.
+- `rauhad` startup in the unprivileged Lima VM with writable `RAUHA_ROOT` fails closed while creating `/sys/fs/cgroup/rauha.slice` with `Permission denied`.
+
+Test-suite adjustment:
+
+- `rauha-oci` overlayfs unit tests now treat Linux `EPERM`/operation-not-permitted mount failures as an unprivileged-environment skip after asserting the expected directory setup. Runtime overlay mount/unmount behavior is unchanged and still returns an error on failure.
+
+Requires follow-up verification:
+
+- Oracle suite in `eval/oracle` with `rauhad` running under a privileged Linux environment.
+- Privileged Linux checks: eBPF LSM load, BPF maps, namespace setup, cgroups, root integration tests.
+- macOS runtime checks: Virtualization.framework VM lifecycle and vsock paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,6 +2485,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rauha-evidence"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "rauha-guest-agent"
 version = "0.1.0"
 dependencies = [
@@ -2561,6 +2574,7 @@ dependencies = [
  "prost 0.13.5",
  "rauha-common",
  "rauha-ebpf-common",
+ "rauha-evidence",
  "rauha-oci",
  "redb",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,15 +1791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,18 +3495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -3525,15 +3504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -3656,12 +3632,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +369,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -547,6 +586,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +682,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1031,6 +1112,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1182,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1418,6 +1516,17 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1842,6 +1951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,6 +2102,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "postcard"
@@ -2302,6 +2445,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "criterion",
  "postcard",
  "serde",
  "serde_json",
@@ -2432,6 +2576,26 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2626,6 +2790,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3040,6 +3213,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3495,6 +3678,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,6 +3875,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,13 @@ edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rauha-runtime/rauha"
 
+[profile.release]
+opt-level = "z"
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = "symbols"
+
 [workspace.dependencies]
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "rauha-common",
     "rauha-ebpf-common",
+    "rauha-evidence",
     "rauhad",
     "rauha-cli",
     "rauha-shim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ clap = { version = "4", features = ["derive"] }
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 
 # OCI
 oci-spec = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", default-features = false, features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 
 # gRPC
 tonic = "0.12"

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -1,0 +1,100 @@
+# Rauha Evidence Surface
+
+Ownership reading for this PR: Syva is the eBPF LSM enforcer. `rauha-evidence`
+is Rauha's evidence/observability surface. It consumes raw Syva/backend records
+plus Rauha lifecycle events and owns schema, projections, and sinks. It does not
+enforce policy and does not add sandbox execution.
+
+## Data Path
+
+Linux:
+
+1. eBPF LSM hooks emit fixed `EnforcementEvent` records into
+   `ENFORCEMENT_EVENTS`.
+2. `ENFORCEMENT_EVENTS` is declared as Aya eBPF `ring_buf::RingBuf`, which maps
+   to `BPF_MAP_TYPE_RINGBUF` rather than perfbuf.
+3. `rauhad` drains the Aya userspace `RingBuf` and normalizes each raw record
+   immediately into `rauha_evidence::FalseEvent`.
+4. The existing gRPC `WatchEvents` API projects the same canonical event into
+   the existing `ZoneEvent` message without changing the proto contract.
+
+macOS:
+
+The macOS backend has no ring buffer. Guest-agent/vsock events must normalize
+into the same `FalseEvent` schema at the adapter edge before reaching sinks.
+That adapter is intentionally not implemented in this observe-only pass.
+
+## Event Taxonomy
+
+All event names are constants in `rauha_evidence::event_name`. The message
+position is stable; variance belongs in event fields.
+
+Reserved sandbox names are present in the schema:
+
+- `task.started`
+- `task.succeeded`
+- `task.failed`
+
+They are not emitted until the separate sandbox runtime PR.
+
+## Projections
+
+One `FalseEvent` supports three renderings:
+
+- machine JSON: `FalseEvent::machine_json()`
+- compact human: `FalseEvent::compact_human()`
+- expanded human: `FalseEvent::expanded_human()`
+
+The daemon emits normalized events through `tracing` with constant message
+`rauha.evidence` and structured fields. The existing gRPC watch surface carries
+machine JSON in `ZoneEvent.message` and the constant canonical name in
+`ZoneEvent.event_type`.
+
+## Cardinality
+
+`rauha_evidence::validate_metric_labels` rejects high-cardinality labels:
+
+- `zone.id`
+- `container.id`
+- `actor.id`
+- `inode`
+- `pid`
+- `connection.id`
+- `trace_id`
+
+These identifiers are event fields only. Aggregate metrics should use
+`event` and bounded zone buckets, never raw IDs.
+
+## Overflow And Shedding
+
+Current behavior:
+
+- BPF ring buffer records use Aya `RingBuf::output`.
+- Userspace subscriber lag in the existing watch API is converted into a
+  `pipeline.shed` event and traced.
+- Undersized ring-buffer records are converted into `pipeline.shed`.
+
+Known gap:
+
+- Kernel-side `RingBuf::output` failure is currently not counted as
+  `ringbuf.drop`; the eBPF program still discards the return value. Evidence is
+  therefore shaped and non-silent once it reaches userspace, but a full kernel
+  ring buffer still needs a dedicated BPF-side counter map to satisfy the
+  `ringbuf.drop` acceptance criterion completely.
+
+Denial records are evidence. Telemetry may be sampled in future work; denials
+must not be sampled away.
+
+## Overhead Measurement
+
+The hot path still emits a fixed-size struct and performs no rendering or string
+interpolation in kernel space. Reproducible overhead measurement requires a
+privileged Linux CI job with:
+
+```sh
+sysctl kernel.bpf_stats_enabled=1
+bpftool prog show
+```
+
+Record `run_cnt` and `run_time_ns` per Rauha LSM program and publish
+`run_time_ns / run_cnt` per event class.

--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ Rauha runs on Linux and macOS; full kernel enforcement is Linux-only.
 
 - **Linux (eBPF enforcement)** — Linux 6.1+ with `CONFIG_BPF_LSM=y`,
   `CONFIG_BPF_SYSCALL=y`, `CONFIG_DEBUG_INFO_BTF=y`; boot parameter
-  `lsm=lockdown,capability,bpf`; BTF at `/sys/kernel/btf/vmlinux`. Network and
-  enforcement setup need root — without it, zones still run but filtering is
-  inactive (rootless development).
+  `lsm=lockdown,capability,bpf`; BTF at `/sys/kernel/btf/vmlinux`. The Linux
+  daemon **fails closed**: it requires root and a working BPF-LSM kernel, and
+  refuses to start without kernel enforcement. For rootless local iteration, use
+  the macOS backend.
 - **macOS (Virtualization.framework)** — macOS 15+ on Apple Silicon or Intel
   with VT-x. `rauhad` must be signed after every build:
   `codesign --entitlements rauhad/rauhad.entitlements -s - target/debug/rauhad`.
@@ -263,8 +264,8 @@ legacy seed and is not extended. See
 - **The two backends are different isolation models** — Linux cgroups/namespaces
   vs. a per-zone VM on macOS; they are not byte-for-byte equivalent.
 - **Linux enforcement needs kernel support** — BPF-LSM, BTF, and compatible
-  struct offsets; offsets are validated at startup and the daemon runs degraded
-  (no enforcement) rather than enforce with wrong offsets.
+  struct offsets; offsets are validated at startup and the daemon **refuses to
+  start** rather than run with no enforcement or with wrong offsets.
 - **Kubernetes integration requires containerd + RuntimeClass wiring**;
   installation docs and examples are still being written.
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ Rauha runs on Linux and macOS; full kernel enforcement is Linux-only.
   `CONFIG_BPF_SYSCALL=y`, `CONFIG_DEBUG_INFO_BTF=y`; boot parameter
   `lsm=lockdown,capability,bpf`; BTF at `/sys/kernel/btf/vmlinux`. The Linux
   daemon **fails closed**: it requires root and a working BPF-LSM kernel, and
-  refuses to start without kernel enforcement. For rootless local iteration, use
-  the macOS backend.
+  refuses to start without kernel enforcement. There is no degraded Linux mode:
+  running zones without Syvä/BPF-LSM enforcement would weaken the isolation
+  contract. For rootless local iteration, use the macOS backend.
 - **macOS (Virtualization.framework)** — macOS 15+ on Apple Silicon or Intel
   with VT-x. `rauhad` must be signed after every build:
   `codesign --entitlements rauhad/rauhad.entitlements -s - target/debug/rauhad`.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,102 @@
 # Rauha
 
-Agent sandbox runtime for controlled, observable execution.
+**Your agents run code you didn't write. Rauha runs it inside a zone you can bound, observe, audit, and enforce.**
 
-Rauha is a sandbox runtime for AI agents, built on controlled execution zones.
-It runs agent tasks where they can be bounded, observed, audited, and later
-enforced by the platform underneath them.
+[![license](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
+[![release](https://img.shields.io/badge/release-v0.1.0-2ea44f.svg)](Cargo.toml)
+[![platform](https://img.shields.io/badge/platform-Linux%20%C2%B7%20macOS-informational.svg)](#requirements)
+[![enforcement](https://img.shields.io/badge/enforcement-Syv%C3%A4%20(Linux%20BPF--LSM)-8a2be2.svg)](#rauha-and-syvä)
 
-## Why Rauha Exists
+Rauha is an agent sandbox runtime built on controlled execution **zones**. A
+zone is the task boundary: it ties together filesystem view, processes,
+networking, resources, policy, logs, audit events, and optional kernel
+enforcement into one unit. You give an agent a task; Rauha runs it in a zone and
+hands back a structured result — stdout, stderr, exit code, and the events the
+task produced.
 
-Agents do not just answer questions anymore.
+No bespoke per-agent sandbox. No "run it on the CI box and hope." Run `rauhad`,
+point the CLI at it, give each task a zone.
 
-They run commands, inspect repositories, modify files, generate patches, call
-APIs, open sockets, spawn processes, and execute tools.
+> *Rauha* (Finnish) — *peace*. What you get when untrusted execution stays inside its boundary.
 
-Most of that execution still happens in environments designed for human
-operators:
+On Linux, the zone is built from cgroups, namespaces, networking, and rootfs
+handling; **Syvä** makes the kernel enforce the boundary with BPF-LSM. On macOS,
+the zone *is* a lightweight VM. Same model, two backends.
 
-- local shells
-- CI runners
-- Docker containers
-- Kubernetes jobs
-- ad-hoc sandboxes
+---
 
-Those environments provide structure, but not a clear task-level execution
-contract. Rauha gives each agent task a zone: an isolated, policy-bound runtime
-boundary with structured execution results and auditability.
+## Contents
 
-## The Short Version
+- [Why Rauha is different](#why-rauha-is-different)
+- [Quickstart](#quickstart)
+- [Agent sandboxing](#agent-sandboxing)
+- [Architecture](#architecture)
+- [Features](#features)
+- [Requirements](#requirements)
+- [Control surface](#control-surface)
+- [How zones work](#how-zones-work)
+- [Rauha and Syvä](#rauha-and-syvä)
+- [Limitations (honest)](#limitations-honest)
+- [Build, test, and verify](#build-test-and-verify)
+- [Roadmap](#roadmap)
+- [License](#license)
 
-Rauha runs each task inside a zone.
+## Why Rauha is different
 
-A zone is the boundary around execution:
+- **The task is the unit, not the container.** A zone wraps one agent task —
+  filesystem, processes, network, policy, and audit — and returns a single
+  structured result. You reason about *what the task did*, not about a pile of
+  container IDs.
+- **One boundary, honestly two backends.** Linux uses cgroups + namespaces +
+  networking with optional in-kernel enforcement; macOS gives each zone its own
+  VM. The daemon is platform-agnostic behind one `IsolationBackend` trait — it
+  never knows which OS it is on.
+- **Observability is part of the boundary.** Every zone exposes logs, audit
+  events, and (on Linux) kernel enforcement events through one watch API.
+  Isolation you cannot observe is isolation you cannot trust.
+- **Enforcement belongs to Syvä.** Rauha creates and runs the zones; the Linux
+  kernel-level deny decisions live behind the Syvä enforcement boundary. Rauha
+  does not pretend the sandbox is a hardware boundary.
 
-- filesystem
-- processes
-- networking
-- resources
-- policy
-- logs
-- audit events
-- enforcement events
+## Quickstart
 
-For an agent, a zone is the sandbox around a task. For a container, a zone is
-the runtime boundary around a workload. For Kubernetes, a zone can back a pod
-or workload. On Linux, Syva can enforce those boundaries inside the kernel.
+Run the daemon (development listens on `[::1]:9876`):
 
-Rauha is an agent sandbox runtime built on a zone-based container runtime, with
-Kubernetes integration as one deployment path.
+```sh
+RUST_LOG=rauhad=debug cargo run --bin rauhad
+```
 
-## Agent Sandboxing
+Create a policy-bound zone, pull an image, and run a container in it:
 
-The intended task-level user experience is:
+```sh
+rauha zone create --name frontend --policy policies/standard.toml
+rauha image pull alpine:latest
+rauha run --zone frontend alpine:latest /bin/echo hello
+rauha ps --zone frontend
+```
 
-```bash
+Watch the zone explain itself — logs, live events, and per-zone resource use:
+
+```sh
+rauha logs <container-id>          # stream container stdout/stderr
+rauha events                       # live zone + enforcement events
+rauha top                          # per-zone resource usage
+```
+
+On macOS, install VM assets and re-sign the daemon first (see
+[Requirements](#requirements)); `rauha setup` provisions the kernel and
+initramfs. Add `--json` to any non-streaming command for machine-readable
+output.
+
+## Agent sandboxing
+
+The task-level shape Rauha is built around:
+
+```sh
 rauha sandbox --image python:3.12 --repo-path . -- pytest tests/
 ```
 
-Structured output should look like:
+returning one structured result:
 
 ```json
 {
@@ -73,284 +113,211 @@ Structured output should look like:
 }
 ```
 
-Status: API contract landed, runtime execution planned. The `rauha sandbox`
-CLI command, the `rauha.sandbox.v1.SandboxService` gRPC service, and the
-`SandboxExecResult` types in `rauha-common` are wired through the daemon and
-CLI. Calling the command today returns:
+**Status — contract landed, runtime planned.** The `rauha sandbox` CLI command,
+the `rauha.sandbox.v1.SandboxService` gRPC service (`proto/sandbox.proto`), and
+the result types in `rauha-common` are wired end to end through the daemon and
+CLI. The daemon currently returns `Unimplemented` for `RunSandbox`:
 
-```
+```text
 Error: sandbox execution is not implemented yet; use zone/run/exec commands or see docs/sandbox-runtime.md
 ```
 
-The runtime path — allocating a task zone, starting a container, waiting,
-capturing stdout/stderr/exit code, collecting enforcement events, and cleaning
-up — is the next PR. Once that lands, the JSON result shape above will be
-populated from real execution without changing the user-facing contract.
-
-The current `rauha run` command starts a container in a zone and returns the
-container ID; it is asynchronous container lifecycle, not task-level execution.
-
-## What Is a Zone?
-
-A zone is not only a namespace.
-A zone is not only a cgroup.
-
-A zone is Rauha's unit of execution, policy, isolation, observability, and
-enforcement.
-
-A zone ties together:
-
-- cgroups
-- namespaces
-- rootfs/filesystem view
-- network namespace, bridge, and rules
-- runtime metadata
-- policy
-- audit stream
-- optional kernel enforcement
-
-On macOS, the zone boundary is a lightweight VM. On Linux, the zone boundary is
-constructed from cgroups, namespaces, networking, rootfs handling, and optional
-kernel enforcement.
-
-## What Rauha Gives You
-
-- controlled agent execution
-- isolated task zones
-- structured stdout/stderr/exit-code result contracts
-- filesystem and process boundaries
-- network policy
-- resource limits
-- logs and audit events
-- future or optional Syva-backed kernel enforcement
-- Kubernetes/containerd integration as a deployment path
-
-## Current CLI
-
-The implemented CLI works at the zone and container level:
-
-```bash
-rauha zone create --name frontend --policy policies/standard.toml
-rauha image pull alpine:latest
-rauha run --zone frontend alpine:latest /bin/echo hello
-rauha ps --zone frontend
-rauha logs <container-id>
-rauha exec <container-id> -- /bin/sh
-rauha stop <container-id>
-rauha delete <container-id>
-rauha zone delete --name frontend --force
-```
-
-Use `--json` on non-streaming commands for machine-readable output.
-
-## Beyond Agents: Zone-Based Containers
-
-Rauha's agent sandbox model is built on a general zone runtime.
-
-The runtime can create zones, place containers inside those zones, apply policy,
-record metadata, expose logs, and report isolation state. This is the technical
-foundation beneath the future task-level sandbox command.
-
-Important crates:
-
-| Crate | Purpose |
-| --- | --- |
-| `rauha-common` | Shared types, `IsolationBackend`, zone/container models, sandbox result types, errors, shim IPC |
-| `rauhad` | Daemon, gRPC server, zone registry, metadata, networking, Linux/macOS backends |
-| `rauha-cli` | CLI binary that talks to `rauhad` |
-| `rauha-shim` | Per-zone Linux shim that forks and runs container processes |
-| `rauha-guest-agent` | Guest-side daemon inside macOS VMs |
-| `rauha-oci` | OCI image pull, content store, rootfs preparation |
-| `containerd-shim-rauha-v2` | containerd shim v2 for Kubernetes/containerd integration |
-| `rauha-enforce` | Transitional workload discovery and zone-mapping agent for existing clusters |
-| `rauha-ebpf` | Current in-repo Linux eBPF LSM programs |
-| `rauha-ebpf-common` | Shared fixed-layout kernel/userspace types |
-| `xtask` | Build helper for eBPF and guest-agent artifacts |
-
-## Kubernetes Integration
-
-Kubernetes is a deployment path, not Rauha's primary identity.
-
-The current repository includes `containerd-shim-rauha-v2`, which bridges
-containerd's Task API to `rauhad`:
-
-```text
-kubelet -> containerd -> containerd-shim-rauha-v2 -> rauhad -> Rauha zone
-```
-
-The shim maps a pod sandbox to a Rauha zone and places app containers in that
-zone. This supports the same zone model under Kubernetes through RuntimeClass
-configuration once installed and wired into containerd.
-
-Existing clusters can also be mapped to zones through `rauha-enforce`, which
-watches workload metadata and programs the current enforcement boundary. That
-role is discovery and zone mapping, not Rauha's product identity.
-
-## Syva-Backed Enforcement
-
-Rauha creates the zones. Syva makes the Linux kernel respect them.
-
-Rauha owns:
-
-- runtime lifecycle
-- zone creation and deletion
-- sandbox/container execution
-- policy loading and validation
-- image/rootfs handling
-- networking
-- metadata
-- logs, audit, and user-facing event surfaces
-- Kubernetes/containerd integration
-
-Syva owns:
-
-- Linux kernel enforcement
-- eBPF LSM programs
-- BPF maps
-- ring buffer events
-- file/open enforcement
-- exec enforcement
-- ptrace enforcement
-- signal enforcement
-- cgroup attach enforcement
-- enforcement counters
-- kernel capability verification
-- privileged kernel self-tests
-
-Current Linux enforcement code may still live inside this repository, but
-architecturally it belongs behind the Syva enforcement boundary.
+The runtime path — allocate a task zone, start the container, wait, capture
+stdout/stderr/exit code, collect enforcement events, clean up (or keep the zone
+with `--keep-zone`) — is the next step. When it lands, the JSON above is
+populated from real execution with no change to the user-facing contract. Today,
+`rauha run` is the working asynchronous container path: it starts a container in
+a zone and returns the container ID.
 
 ## Architecture
 
-Rauha is split around the `IsolationBackend` trait in
-`rauha-common/src/backend.rs`. The daemon is platform-agnostic and delegates
-zone/container work to the active backend.
+Policy and tasks come in through the CLI or containerd; the daemon delegates all
+zone/container work to the active platform backend; logs, audit, and enforcement
+events flow back out through one watch API.
 
-Linux backend:
+| Crate | Role |
+| --- | --- |
+| `rauhad` | Daemon — gRPC server, zone registry, metadata (redb), networking, Linux/macOS backends |
+| `rauha-cli` (`rauha`) | Operator CLI over the daemon's gRPC API |
+| `rauha-common` | Shared types, the `IsolationBackend` trait, policy parsing, sandbox result types, shim IPC protocol |
+| `rauha-shim` | Per-*zone* sync process (Linux) — forks and runs container processes |
+| `rauha-guest-agent` | Guest-side daemon inside macOS VMs — container lifecycle over virtio-vsock |
+| `rauha-oci` | OCI image pull, content store, rootfs preparation, runtime spec generation |
+| `rauha-evidence` | Evidence-grade observability schema, projections, and sinks (does not enforce) |
+| `containerd-shim-rauha-v2` | containerd shim v2 — bridges containerd's Task API to `rauhad` for Kubernetes |
+| `rauha-enforce` | Legacy in-repo enforcement seed — superseded by Syvä; do not extend |
+| `rauha-ebpf` / `rauha-ebpf-common` | In-repo Linux eBPF LSM programs and shared `repr(C)` types (separate build) |
+| `xtask` | Build helper for eBPF and guest-agent artifacts |
 
-- cgroups v2 for membership and resource grouping
-- namespaces and rootfs setup through the per-zone shim
-- network namespaces, veth pairs, bridge, and nftables
-- current in-repo eBPF LSM integration for syscall-level enforcement
-- enforcement events streamed through a BPF ring buffer and gRPC watch API
+**One shim per zone, not per container.** Zones are the isolation boundary, so
+`rauhad` spawns one `rauha-shim` per zone; the shim forks additional container
+processes on request. This diverges deliberately from containerd's
+one-shim-per-container model.
 
-macOS backend:
+## Features
 
-- one lightweight Linux VM per zone through Virtualization.framework
-- virtio-vsock to the guest agent
-- virtio-fs/APFS clonefile-backed rootfs handling
-- pf anchors for network policy where available
+- **Zone-scoped execution** — filesystem view, processes, network, resources,
+  policy, and audit bound to one task or workload.
+- **Structured task results** — stdout / stderr / exit code / duration /
+  enforcement events captured into one contract (`SandboxService`, runtime
+  landing).
+- **Two isolation backends** — Linux (cgroups v2, namespaces, veth/bridge +
+  nftables NAT, rootfs via the per-zone shim) and macOS (one
+  Virtualization.framework VM per zone, virtio-fs + APFS `clonefile`, pf
+  anchors).
+- **Zone networking** — each zone gets a unique IP from `10.89.0.0/16` via the
+  `rauha0` bridge with nftables NAT masquerade; per-zone forward chains default
+  to drop.
+- **Observability built in** — `rauha logs`, `rauha events`, `rauha trace`, and
+  `rauha top`; on Linux, kernel deny events stream from a BPF ring buffer through
+  the `WatchEvents` gRPC API and `rauha-evidence` normalizes them.
+- **TOML policy** — zone type, filesystem rules, network mode and egress,
+  resource limits, capabilities, and allowed cross-zone communication
+  (`policies/standard.toml`).
+- **Kubernetes deployment path** — `containerd-shim-rauha-v2` maps a pod sandbox
+  to a Rauha zone via `runtimeClassName: rauha`.
 
-The two backends are intentionally different. Linux uses OS-level isolation
-plus optional kernel enforcement. macOS uses a VM boundary per zone.
+## Requirements
 
-## Policy Model
+Rauha runs on Linux and macOS; full kernel enforcement is Linux-only.
 
-Policies are TOML. See `policies/standard.toml`.
+- **Linux (eBPF enforcement)** — Linux 6.1+ with `CONFIG_BPF_LSM=y`,
+  `CONFIG_BPF_SYSCALL=y`, `CONFIG_DEBUG_INFO_BTF=y`; boot parameter
+  `lsm=lockdown,capability,bpf`; BTF at `/sys/kernel/btf/vmlinux`. Network and
+  enforcement setup need root — without it, zones still run but filtering is
+  inactive (rootless development).
+- **macOS (Virtualization.framework)** — macOS 15+ on Apple Silicon or Intel
+  with VT-x. `rauhad` must be signed after every build:
+  `codesign --entitlements rauhad/rauhad.entitlements -s - target/debug/rauhad`.
+  VM assets (vmlinux + initramfs) install to `/var/lib/rauha/vm/` via
+  `rauha setup`.
 
-Policy can describe:
+Root directory: `/var/lib/rauha` on Linux, `/tmp/rauha` on macOS (override with
+`RAUHA_ROOT`).
 
-- zone type
-- filesystem rules
-- network mode and egress
-- resource limits
-- capabilities
-- syscall policy
-- devices
-- allowed zone communication
+## Control surface
 
-Rauha owns user-facing policy. Linux kernel-facing enforcement policy should
-eventually be translated into Syva's policy and map model behind an explicit
-boundary.
+The CLI is a thin client of the daemon's gRPC API (`RAUHA_ADDR`, default
+`http://[::1]:9876`).
 
-## Current Status
+```sh
+rauha zone create --name frontend --policy policies/standard.toml
+rauha zone list
+rauha image pull alpine:latest
+rauha run --zone frontend alpine:latest /bin/echo hello
+rauha ps --zone frontend
+rauha exec <container-id> -- /bin/sh    # exec in a running container
+rauha attach <container-id>             # attach to a running container
+rauha logs <container-id>               # stream stdout/stderr
+rauha events                            # live zone + enforcement events
+rauha trace --zone frontend             # per-zone syscall trace
+rauha top                               # per-zone resource usage
+rauha policy show --zone frontend
+rauha stop <container-id> && rauha delete <container-id>
+rauha zone delete --name frontend --force
+rauha sandbox --image python:3.12 -- pytest   # task-level (runtime landing)
+```
 
-Implemented today:
+`trace`, `top`, `events`, `logs`, `exec`, `attach`, and `setup` are streaming or
+interactive and do not take `--json`.
 
-- zone create/list/show/delete
-- policy parse/apply/show
-- container create/start/stop/delete/list
-- image pull/list/inspect/remove
-- logs, exec, attach, trace/events surfaces
-- `IsolationBackend` abstraction
-- Linux backend with cgroups, namespaces, networking, shim orchestration, and
-  current in-repo eBPF LSM support
-- macOS VM-per-zone backend path
-- containerd shim v2 code path
-- `rauha-enforce` transitional workload discovery/zone mapping agent
-- structured sandbox result types in `rauha-common`
-- gRPC oracle suite under `eval/oracle`
+## How zones work
 
-Planned:
+A zone is not just a namespace and not just a cgroup. It is Rauha's unit of
+execution, policy, isolation, observability, and enforcement, tying together:
+cgroups, namespaces, rootfs/filesystem view, network namespace + bridge + rules,
+runtime metadata, policy, the audit stream, and optional kernel enforcement.
 
-- `rauha sandbox` task-level CLI
-- synchronous sandbox execution API
-- structured task result emission from the daemon
-- cleanup/keep-zone behavior for task zones
-- sandbox enforcement event collection in task results
-- explicit Syva enforcer boundary
-- external Syva integration
-- Kubernetes installation docs and RuntimeClass examples
+User-visible zone IDs are UUIDs (persisted in redb, the source of truth on crash
+recovery); kernel-side they compact to `u32` BPF map keys. On startup `rauhad`
+reconciles from redb — re-establishing cgroups, networking, and (on Linux) BPF
+map state — then cleans up orphaned kernel state. On macOS the zone boundary is
+the VM itself, so no cgroups or namespaces are needed.
 
-Future:
+## Rauha and Syvä
 
-- move or wrap in-repo eBPF code behind Syva
-- privileged Syva/Rauha kernel enforcement test suite
-- richer agent orchestration/SDK surfaces
-- deeper workload discovery for existing clusters
+**Rauha creates the zones. Syvä makes the Linux kernel respect them.**
 
-## Building and Testing
+| Rauha owns | Syvä owns |
+| --- | --- |
+| Runtime lifecycle, zone create/delete | Linux kernel enforcement (BPF-LSM) |
+| Sandbox/container execution | eBPF programs, BPF maps, ring-buffer events |
+| Policy loading and validation | file / exec / ptrace / signal / socket deny decisions |
+| Image, rootfs, networking, metadata | per-hook counters and privileged self-tests |
+| Logs, audit, user-facing event surfaces | the in-kernel deny-before-it-happens decision |
+| Kubernetes / containerd integration | |
 
-```bash
-cargo build
-cargo test
-cargo build --bin rauhad
-cargo build --bin rauha
-cargo build --bin rauha-shim
-cargo build --bin rauha-guest-agent
-cargo build --bin rauha-enforce
+Syvä is a separate product ([`github.com/false-systems/syva`](https://github.com/false-systems/syva)).
+Current Linux eBPF code may still live in this repository, but architecturally it
+belongs behind the Syvä enforcement boundary; the `rauha-enforce` crate is a
+legacy seed and is not extended. See
+[`docs/rauha-syva-boundary.md`](docs/rauha-syva-boundary.md).
+
+## Limitations (honest)
+
+- **`rauha sandbox` is a contract, not yet a runtime** — the daemon returns
+  `Unimplemented` for `RunSandbox` today. Use `zone` / `run` / `exec` meanwhile.
+- **A sandbox, not a hardware boundary** — BPF-LSM is OS-level isolation and is
+  additive-only: it can deny, but cannot override SELinux/AppArmor MAC denials.
+  Covert channels through shared kernel resources are out of scope.
+- **The two backends are different isolation models** — Linux cgroups/namespaces
+  vs. a per-zone VM on macOS; they are not byte-for-byte equivalent.
+- **Linux enforcement needs kernel support** — BPF-LSM, BTF, and compatible
+  struct offsets; offsets are validated at startup and the daemon runs degraded
+  (no enforcement) rather than enforce with wrong offsets.
+- **Kubernetes integration requires containerd + RuntimeClass wiring**;
+  installation docs and examples are still being written.
+
+## Build, test, and verify
+
+```sh
+cargo build                          # all workspace crates
+cargo test                           # all unit tests
 cargo build -p containerd-shim-rauha-v2
+cargo xtask build-ebpf --release     # eBPF object (nightly Rust; separate build)
 ```
 
-Run the daemon:
+Run the daemon and drive it with the CLI:
 
-```bash
+```sh
 RUST_LOG=rauhad=debug cargo run --bin rauhad
-```
-
-Use the CLI:
-
-```bash
 cargo run --bin rauha -- zone create --name test
-cargo run --bin rauha -- image pull alpine:latest
 cargo run --bin rauha -- run --zone test alpine:latest /bin/echo hello
 ```
 
-Build eBPF programs:
+The **oracle** is a ground-truth gRPC suite (55 numbered cases) that validates
+`rauhad` through its public API only — it never reads source or mocks. It needs a
+running daemon:
 
-```bash
-cargo xtask build-ebpf
-```
-
-Oracle tests live in `eval/oracle` and require a running daemon:
-
-```bash
+```sh
 cd eval/oracle
-RAUHA_GRPC_ENDPOINT=http://[::1]:9876 cargo test
+RAUHA_GRPC_ENDPOINT=http://[::1]:9876 cargo test            # all cases
+RAUHA_GRPC_ENDPOINT=http://[::1]:9876 cargo test -- case_001 # one case
 ```
 
-Linux integration tests under `tests/integration` require root and a running
-daemon. eBPF enforcement tests require a kernel with BPF LSM support.
+Linux integration tests under `tests/integration/` require root and a running
+daemon (eBPF gates need a BPF-LSM kernel):
 
-## Trade-Offs
+```sh
+bash tests/integration/test-zone-isolation.sh
+bash tests/integration/test-zone-networking.sh
+bash tests/integration/test-cgroup-lock.sh     # eBPF enforcement required
+```
 
-- eBPF LSM is OS-level isolation, not a hardware boundary.
-- macOS VM-per-zone isolation is a different model from Linux cgroups and
-  namespaces.
-- LSM is additive-only: BPF LSM can deny access but cannot override SELinux,
-  AppArmor, or other MAC denials.
-- Current Linux enforcement depends on kernel support for BPF LSM, BTF, and
-  compatible struct offsets.
-- Covert channels through shared kernel resources are out of scope.
-- Kubernetes integration requires containerd and RuntimeClass configuration.
-- The task-level `rauha sandbox` command is planned, not implemented.
+## Roadmap
+
+- Synchronous `rauha sandbox` runtime: task-zone allocation, execution, result
+  emission, and `--keep-zone` / cleanup behavior.
+- An explicit Syvä enforcer boundary, then external Syvä integration; move or
+  wrap the in-repo eBPF code behind it.
+- A privileged Syvä/Rauha kernel-enforcement test suite.
+- Kubernetes installation docs and `RuntimeClass` examples; deeper workload
+  discovery for existing clusters.
+- Richer agent orchestration / SDK surfaces.
+
+## License
+
+Licensed under the [Apache License, Version 2.0](LICENSE). Unless you explicitly
+state otherwise, any contribution intentionally submitted for inclusion in this
+work as defined in the Apache-2.0 license shall be licensed as above, without any
+additional terms or conditions.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -167,6 +167,67 @@ Requires privileged/macOS CI verification:
 - eBPF LSM load, BPF maps, namespace setup, cgroups, and root integration tests.
 - macOS Virtualization.framework VM lifecycle and vsock paths.
 
+## Phase 3: eBPF Hook Error Paths Fail Closed
+
+Lever: eBPF LSM hook internal error branches only.
+
+Before:
+
+- `file_open`, `bprm_check_security`, `ptrace_access_check`, `task_kill`,
+  `cgroup_attach_task`, and `capable` emitted an error event on internal
+  lookup/logic failure, then returned allow from the hook.
+
+After:
+
+- The same error branches still emit the error event, but return deny from the
+  hook. Explicit unzoned, global, same-zone, and allow-list paths are unchanged.
+- `socket_connect` remains unchanged because it is currently audit-only and
+  network enforcement is delegated outside this hook.
+
+eBPF object size delta:
+
+| Artifact | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauha-ebpf` object | 11,152 | 11,192 | +40 | +0.36% |
+
+Commands:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-ebpf-before cargo run -p xtask -- build-ebpf
+CARGO_TARGET_DIR=$HOME/rauha-target-ebpf-after-obj cargo run -p xtask -- build-ebpf
+stat -c '%s' $HOME/rauha-target-ebpf-before/bpfel-unknown-none/debug/rauha-ebpf
+stat -c '%s' $HOME/rauha-target-ebpf-after-obj/bpfel-unknown-none/debug/rauha-ebpf
+```
+
+Correctness notes:
+
+- This strengthens fail-closed behavior and does not add a permissive fallback.
+- This change does not alter CLI grammar, gRPC contracts, sandbox types, or the
+  `IsolationBackend` trait.
+- `rauha sandbox` remains the explicit unimplemented contract.
+- Capability policy semantics for missing/zero policy entries are intentionally
+  left for a separate deny-by-default policy lever with focused tests.
+
+Verification:
+
+- Linux `cargo build --workspace` passed.
+- Linux `cargo test --workspace` passed.
+- Linux `cargo clippy --workspace --all-targets` passed with existing warnings.
+- macOS `cargo check -p rauhad` passed on the host with existing warnings.
+- Lima eBPF build `cargo run -p xtask -- build-ebpf` passed after installing
+  `rust-src` for nightly and `bpf-linker`. Host eBPF build failed because the
+  local `bpf-linker` could not find an LLVM shared library.
+- Oracle suite in `eval/oracle` compiled, then failed before exercising Rauha:
+  all 55 cases failed at connection setup because no daemon was listening on
+  `http://[::1]:9876` (`Connection refused`). This requires a running privileged
+  Linux `rauhad` environment.
+
+Requires privileged/macOS CI verification:
+
+- eBPF LSM load, verifier acceptance, hook attach, and runtime deny behavior for
+  the changed hook error branches.
+- macOS Virtualization.framework VM lifecycle and vsock paths.
+
 ## Phase 1: Tokio Feature Diet
 
 Lever: workspace direct Tokio dependency features only.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,0 +1,97 @@
+# Rauha Results
+
+Captured: 2026-06-14
+
+Measurement environment for Linux binary sizes: Lima instance `ubuntu`,
+`aarch64-unknown-linux-gnu`, same workspace checkout as this commit.
+
+## Phase 1: Release Profile
+
+Lever: workspace release profile only.
+
+Chosen profile:
+
+```toml
+[profile.release]
+opt-level = "z"
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = "symbols"
+```
+
+`opt-level = "z"` and `"s"` were both measured with the same LTO, codegen,
+panic, and strip settings. `z` was smaller for every required binary, so `z`
+was selected.
+
+Commands:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-size-before cargo build --release --bins
+CARGO_PROFILE_RELEASE_OPT_LEVEL=z \
+  CARGO_PROFILE_RELEASE_LTO=fat \
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
+  CARGO_PROFILE_RELEASE_PANIC=abort \
+  CARGO_PROFILE_RELEASE_STRIP=symbols \
+  CARGO_TARGET_DIR=$HOME/rauha-target-size-z \
+  cargo build --release --bins
+CARGO_PROFILE_RELEASE_OPT_LEVEL=s \
+  CARGO_PROFILE_RELEASE_LTO=fat \
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
+  CARGO_PROFILE_RELEASE_PANIC=abort \
+  CARGO_PROFILE_RELEASE_STRIP=symbols \
+  CARGO_TARGET_DIR=$HOME/rauha-target-size-s \
+  cargo build --release --bins
+```
+
+Before sizes are current stripped release binaries before this profile change.
+After sizes are release binaries emitted by the selected profile, which strips
+symbols as part of the build.
+
+| Binary | Before stripped bytes | `z` bytes | `s` bytes | Selected delta | Selected delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `rauhad` | 8,341,328 | 4,212,464 | 4,540,144 | -4,128,864 | -49.50% |
+| `rauha` | 4,929,224 | 2,438,776 | 2,635,360 | -2,490,448 | -50.52% |
+| `rauha-shim` | 3,349,200 | 2,104,000 | 2,235,072 | -1,245,200 | -37.18% |
+| `rauha-guest-agent` | 2,955,840 | 1,907,240 | 2,038,320 | -1,048,600 | -35.48% |
+| `rauha-enforce` | 4,798,792 | 2,701,600 | 2,898,160 | -2,097,192 | -43.70% |
+| `containerd-shim-rauha-v2` | 5,845,816 | 2,823,528 | 3,085,672 | -3,022,288 | -51.70% |
+
+Current unstripped pre-profile release sizes, measured before this lever:
+
+| Binary | Unstripped bytes |
+| --- | ---: |
+| `rauhad` | 11,847,128 |
+| `rauha` | 6,981,472 |
+| `rauha-shim` | 4,717,488 |
+| `rauha-guest-agent` | 4,188,632 |
+| `rauha-enforce` | 6,972,808 |
+| `containerd-shim-rauha-v2` | 8,489,080 |
+
+Correctness notes:
+
+- This profile does not change CLI grammar, gRPC contracts, sandbox types, or
+  the `IsolationBackend` trait.
+- `panic = "abort"` does not add a permissive fallback. It makes any remaining
+  panic terminate the process instead of unwinding; request and enforcement path
+  panics still need to be removed under the strictness work.
+- No isolation checks or enforcement setup are skipped for size.
+
+Verification:
+
+- Linux selected release build:
+  `CARGO_TARGET_DIR=$HOME/rauha-target-size-after cargo build --release --bins`
+  passed and reproduced the selected size table above.
+- Linux `cargo build --workspace` passed.
+- Linux `cargo test --workspace` passed.
+- Linux `cargo clippy --workspace --all-targets` passed with existing warnings.
+- macOS `cargo check -p rauhad` passed on the host with existing warnings.
+- Oracle suite in `eval/oracle` compiled, then failed before exercising Rauha:
+  all 55 cases failed at connection setup because no daemon was listening on
+  `http://[::1]:9876` (`Connection refused`). This requires a running privileged
+  Linux `rauhad` environment.
+
+Requires privileged/macOS CI verification:
+
+- eBPF LSM load, BPF maps, namespace setup, cgroups, and root integration tests.
+- macOS Virtualization.framework VM lifecycle and vsock paths.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -228,6 +228,97 @@ Requires privileged/macOS CI verification:
   the changed hook error branches.
 - macOS Virtualization.framework VM lifecycle and vsock paths.
 
+## Phase 3: Linux Enforcement Setup Fails Closed
+
+Lever: Linux eBPF enforcement setup and capability allow-list semantics.
+
+Before:
+
+- `LinuxBackend::new` logged and continued when eBPF programs failed to load,
+  leaving `rauhad` able to run without kernel enforcement.
+- Missing enforcement event ring-buffer setup logged and continued.
+- Linux `create_zone` logged BPF membership/policy map failures and still
+  returned a zone handle.
+- Linux `create_zone` logged cgroup resource limit failures and still returned a
+  zone handle.
+- Linux `recover_zone` logged BPF map and resource-limit restore failures and
+  treated the zone as recovered.
+- The `capable` LSM hook treated a missing `ZONE_POLICY` entry or
+  `caps_mask == 0` as unrestricted capability use for zoned non-global callers.
+
+After:
+
+- `LinuxBackend::new` returns an `EbpfError` unless eBPF programs load and the
+  enforcement event ring buffer can be opened.
+- `create_zone` returns an error and rolls back cgroup, netns/veth, IP
+  allocation, and in-memory zone id/name state if BPF membership, BPF policy, or
+  hard cgroup resource setup fails.
+- `recover_zone` returns an error if hard cgroup limits or BPF map state cannot
+  be restored.
+- For zoned non-global callers, the `capable` hook denies invalid capability
+  numbers, missing `ZONE_POLICY`, and any capability not present in
+  `caps_mask`. A zero mask now means an empty allow-list.
+- Global and unzoned callers remain unchanged.
+
+Release binary size delta:
+
+| Binary | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauhad` | 4,145,832 | 4,145,664 | -168 | -0.00% |
+| `rauha` | 2,437,688 | 2,437,688 | 0 | 0.00% |
+| `rauha-shim` | 2,037,376 | 2,037,376 | 0 | 0.00% |
+| `rauha-guest-agent` | 1,906,152 | 1,906,152 | 0 | 0.00% |
+| `rauha-enforce` | 2,634,968 | 2,634,968 | 0 | 0.00% |
+| `containerd-shim-rauha-v2` | 2,823,528 | 2,823,528 | 0 | 0.00% |
+
+eBPF object size delta:
+
+| Artifact | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauha-ebpf` object | 11,192 | 11,440 | +248 | +2.22% |
+
+Commands:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-strict-pr cargo build --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-strict-pr cargo test --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-strict-pr cargo clippy --workspace --all-targets
+CARGO_TARGET_DIR=$HOME/rauha-target-strict-pr-release cargo build --release --bins
+CARGO_TARGET_DIR=$HOME/rauha-target-strict-pr-ebpf cargo run -p xtask -- build-ebpf
+```
+
+Correctness notes:
+
+- This strengthens fail-closed behavior and does not add a permissive fallback.
+- This change does not alter CLI grammar, gRPC contracts, sandbox types, or the
+  `IsolationBackend` trait.
+- `rauha sandbox` remains the explicit unimplemented contract.
+- The macOS backend is not behaviorally changed. macOS remains a hardware VM
+  boundary and was compile-checked on the host.
+
+Verification:
+
+- Linux `cargo build --workspace` passed.
+- Linux `cargo test --workspace` passed.
+- Linux `cargo clippy --workspace --all-targets` passed with existing warnings.
+- Linux release build `cargo build --release --bins` passed and produced the
+  size table above.
+- Lima eBPF build `cargo run -p xtask -- build-ebpf` passed and produced the
+  object-size table above.
+- macOS `cargo check -p rauhad` passed on the host with existing warnings.
+- Oracle suite in `eval/oracle` compiled, then failed before exercising Rauha:
+  all 55 cases failed at connection setup because no daemon was listening on
+  `http://[::1]:9876` (`Connection refused`). This requires a running privileged
+  Linux `rauhad` environment.
+
+Requires privileged/macOS CI verification:
+
+- Linux eBPF LSM load, verifier acceptance, hook attach, ring-buffer event
+  delivery, and runtime capability-deny behavior.
+- Linux privileged zone create/recover rollback behavior against real cgroups,
+  namespaces, BPF maps, and resource controllers.
+- macOS Virtualization.framework VM lifecycle and vsock paths.
+
 ## Phase 1: Tokio Feature Diet
 
 Lever: workspace direct Tokio dependency features only.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -171,6 +171,79 @@ Verification:
   `http://[::1]:9876` (`Connection refused`). This requires a running privileged
   Linux `rauhad` environment.
 
+## Phase 3: Linux Backend Mutex Poisoning Fails Closed
+
+Lever: Linux backend daemon-state mutex poisoning on lifecycle and enforcement
+paths.
+
+Before:
+
+- `rauhad` aborted the whole process on several poisoned Linux backend mutexes.
+- Some BPF update paths used raw `self.ebpf.lock()` and silently skipped BPF
+  policy/inode work if the mutex was poisoned.
+
+After:
+
+- Linux backend locks go through a typed fail-closed helper that returns
+  `RauhaError::BackendError("linux backend state poisoned: ...")`.
+- Zone ID allocation/lookup/removal are fallible, so create/recover/destroy,
+  policy update, container start/stop, rootfs inode registration, and
+  `verify_isolation` refuse the operation on poisoned state instead of aborting
+  or skipping enforcement work.
+- Rollback remains best-effort, but poisoned rollback state is logged and does
+  not convert an enforcement/setup failure into a permissive success.
+
+Release binary size delta:
+
+| Binary | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauhad` | 4,145,664 | 4,145,304 | -360 | -0.01% |
+| `rauha` | 2,437,688 | 2,437,688 | 0 | 0.00% |
+| `rauha-shim` | 2,102,912 | 2,102,912 | 0 | 0.00% |
+| `rauha-guest-agent` | 1,906,152 | 1,906,152 | 0 | 0.00% |
+| `rauha-enforce` | 2,700,504 | 2,700,504 | 0 | 0.00% |
+| `containerd-shim-rauha-v2` | 2,823,528 | 2,823,528 | 0 | 0.00% |
+
+Commands:
+
+```sh
+cargo check -p rauhad
+CARGO_TARGET_DIR=$HOME/rauha-target-lock-strict cargo build --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-lock-strict cargo test --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-lock-strict cargo clippy --workspace --all-targets
+CARGO_TARGET_DIR=$HOME/rauha-target-lock-strict-release cargo build --release --bins
+CARGO_TARGET_DIR=$HOME/rauha-target-lock-strict-ebpf cargo run -p xtask -- build-ebpf
+```
+
+Correctness notes:
+
+- This strengthens request/enforcement-path robustness: poisoned daemon state
+  now refuses the current operation instead of panicking/aborting the daemon or
+  silently skipping BPF updates.
+- No isolation checks, enforcement setup, namespace setup, policy validation, or
+  VM boundaries are relaxed.
+- This change does not alter CLI grammar, gRPC contracts, sandbox types, or the
+  `IsolationBackend` trait.
+- `rauha sandbox` remains the explicit unimplemented contract.
+- The macOS backend is not behaviorally changed and was compile-checked through
+  `rauhad` on the host.
+
+Verification:
+
+- macOS `cargo check -p rauhad` passed on the host with existing warnings.
+- Linux `cargo build --workspace` passed.
+- Linux `cargo test --workspace` passed, including
+  `backend::linux::tests::poisoned_backend_lock_returns_error`.
+- Linux `cargo clippy --workspace --all-targets` passed with existing warnings.
+- Linux release build `cargo build --release --bins` passed and produced the
+  size table above.
+- Lima eBPF build `cargo run -p xtask -- build-ebpf` passed with existing
+  warnings.
+- Oracle suite in `eval/oracle` compiled, then failed before exercising Rauha:
+  all 55 cases failed at connection setup because no daemon was listening on
+  `http://[::1]:9876` (`Connection refused`). This requires a running privileged
+  Linux `rauhad` environment.
+
 ## Phase 1: Tracing Subscriber Feature Diet
 
 Lever: workspace direct `tracing-subscriber` dependency features only.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -95,3 +95,73 @@ Requires privileged/macOS CI verification:
 
 - eBPF LSM load, BPF maps, namespace setup, cgroups, and root integration tests.
 - macOS Virtualization.framework VM lifecycle and vsock paths.
+
+## Phase 1: Tokio Feature Diet
+
+Lever: workspace direct Tokio dependency features only.
+
+Before:
+
+```toml
+tokio = { version = "1", features = ["full"] }
+```
+
+After:
+
+```toml
+tokio = { version = "1", default-features = false, features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+```
+
+The selected direct feature set covers the workspace's direct Tokio usage:
+`#[tokio::main]`, `#[tokio::test]`, `tokio::spawn`, `spawn_blocking`,
+`select!`, timers, signals, Unix streams, async stdio, async read/write
+helpers, and sync channels/locks.
+
+Commands:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-tokio-diet cargo build --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-tokio-diet-release cargo build --release --bins
+cargo tree -e features -i tokio
+```
+
+The release binary size delta is zero for this lever:
+
+| Binary | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauhad` | 4,212,464 | 4,212,464 | 0 | 0.00% |
+| `rauha` | 2,438,776 | 2,438,776 | 0 | 0.00% |
+| `rauha-shim` | 2,104,000 | 2,104,000 | 0 | 0.00% |
+| `rauha-guest-agent` | 1,907,240 | 1,907,240 | 0 | 0.00% |
+| `rauha-enforce` | 2,701,600 | 2,701,600 | 0 | 0.00% |
+| `containerd-shim-rauha-v2` | 2,823,528 | 2,823,528 | 0 | 0.00% |
+
+Dependency notes:
+
+- Rauha no longer requests `tokio/full` directly from the workspace dependency.
+- `cargo tree -e features -i tokio` still shows `tokio/full` enabled
+  transitively by `containerd-shim v0.10.0`, including `fs`, `process`, and
+  `parking_lot`. That transitive dependency explains the zero-byte binary-size
+  result.
+- The next measurable dependency-size lever is likely around the
+  `containerd-shim`/TTRPC stack or feature-gating the shim binary, not Tokio
+  features in Rauha's direct dependency declaration.
+
+Correctness notes:
+
+- This change does not alter CLI grammar, gRPC contracts, sandbox types, or the
+  `IsolationBackend` trait.
+- No isolation checks, enforcement setup, policy validation, or fail-closed
+  paths are relaxed.
+- `rauha sandbox` remains the explicit unimplemented contract.
+
+Verification:
+
+- Linux `cargo build --workspace` passed.
+- Linux `cargo test --workspace` passed.
+- Linux `cargo clippy --workspace --all-targets` passed with existing warnings.
+- macOS `cargo check -p rauhad` passed on the host with existing warnings.
+- Oracle suite in `eval/oracle` compiled, then failed before exercising Rauha:
+  all 55 cases failed at connection setup because no daemon was listening on
+  `http://[::1]:9876` (`Connection refused`). This requires a running privileged
+  Linux `rauhad` environment.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -91,6 +91,77 @@ Verification:
   `http://[::1]:9876` (`Connection refused`). This requires a running privileged
   Linux `rauhad` environment.
 
+## Phase 1: Tracing Subscriber Feature Diet
+
+Lever: workspace direct `tracing-subscriber` dependency features only.
+
+Before:
+
+```toml
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+```
+
+After:
+
+```toml
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+```
+
+The selected feature set covers the workspace's direct subscriber usage:
+`tracing_subscriber::fmt()`, `EnvFilter::from_default_env()`,
+`with_env_filter(...)`, and `init()`. Rauha does not use subscriber-provided
+ANSI coloring, `tracing-log` bridging, JSON formatting, local time, or valuable
+support on these initialization paths.
+
+Commands:
+
+```sh
+CARGO_TARGET_DIR=$HOME/rauha-target-tracing-diet cargo build --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-tracing-diet-release cargo build --release --bins
+cargo tree -e features -i tracing-subscriber
+```
+
+Release binary size delta:
+
+| Binary | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauhad` | 4,212,464 | 4,145,832 | -66,632 | -1.58% |
+| `rauha` | 2,438,776 | 2,437,688 | -1,088 | -0.04% |
+| `rauha-shim` | 2,104,000 | 2,037,376 | -66,624 | -3.17% |
+| `rauha-guest-agent` | 1,907,240 | 1,906,152 | -1,088 | -0.06% |
+| `rauha-enforce` | 2,701,600 | 2,634,968 | -66,632 | -2.47% |
+| `containerd-shim-rauha-v2` | 2,823,528 | 2,823,528 | 0 | 0.00% |
+
+Dependency notes:
+
+- `cargo tree -e features -i tracing-subscriber` no longer shows
+  `tracing-subscriber/default`, `ansi`, `nu-ansi-term`, `tracing-log`, or
+  `smallvec` requested by Rauha.
+- Remaining required subscriber features are `fmt`, `env-filter`, `registry`,
+  `std`, `thread_local`, `matchers`, `once_cell`, `sharded-slab`, and
+  `tracing`.
+- `containerd-shim-rauha-v2` did not shrink measurably under the final stripped
+  size profile; its heavier containerd/TTRPC dependency graph still dominates.
+
+Correctness notes:
+
+- This change does not alter CLI grammar, gRPC contracts, sandbox types, or the
+  `IsolationBackend` trait.
+- No enforcement, policy validation, lifecycle, or fail-closed path is changed.
+- Logging remains initialized with the same `fmt` subscriber and env filter
+  behavior, minus unused default formatting support.
+
+Verification:
+
+- Linux `cargo build --workspace` passed.
+- Linux `cargo test --workspace` passed.
+- Linux `cargo clippy --workspace --all-targets` passed with existing warnings.
+- macOS `cargo check -p rauhad` passed on the host with existing warnings.
+- Oracle suite in `eval/oracle` compiled, then failed before exercising Rauha:
+  all 55 cases failed at connection setup because no daemon was listening on
+  `http://[::1]:9876` (`Connection refused`). This requires a running privileged
+  Linux `rauhad` environment.
+
 Requires privileged/macOS CI verification:
 
 - eBPF LSM load, BPF maps, namespace setup, cgroups, and root integration tests.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -319,6 +319,88 @@ Requires privileged/macOS CI verification:
   namespaces, BPF maps, and resource controllers.
 - macOS Virtualization.framework VM lifecycle and vsock paths.
 
+## Phase 3: Strict Policy Parsing
+
+Lever: policy input validation only.
+
+Before:
+
+- TOML policy structs accepted unknown top-level and nested keys.
+- Unknown Linux capability names were accepted by policy parsing and silently
+  collapsed out of the kernel capability mask.
+- Programmatic `ZonePolicy` values with unknown capability names could reach
+  `rauhad` / `rauha-enforce` BPF map conversion and produce a narrower or empty
+  mask without an explicit validation error.
+
+After:
+
+- Policy TOML deserialization uses `deny_unknown_fields` for every policy
+  section.
+- Linux capability names are validated in `rauha-common`; short names and case
+  variation remain accepted (`net_admin`, `CAP_NET_ADMIN`, etc.).
+- Unknown capability names return `InvalidPolicy` before a policy reaches BPF
+  map conversion.
+- `rauhad` and `rauha-enforce` both use the shared validator when building
+  `ZonePolicyKernel`.
+
+Release binary size delta:
+
+| Binary | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauhad` | 4,145,664 | 4,145,664 | 0 | 0.00% |
+| `rauha` | 2,437,688 | 2,437,688 | 0 | 0.00% |
+| `rauha-shim` | 2,037,376 | 2,037,376 | 0 | 0.00% |
+| `rauha-guest-agent` | 1,906,152 | 1,906,152 | 0 | 0.00% |
+| `rauha-enforce` | 2,634,968 | 2,700,504 | +65,536 | +2.49% |
+| `containerd-shim-rauha-v2` | 2,823,528 | 2,823,528 | 0 | 0.00% |
+
+eBPF object size delta:
+
+| Artifact | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauha-ebpf` object | 11,440 | 11,440 | 0 | 0.00% |
+
+Commands:
+
+```sh
+cargo check -p rauhad
+CARGO_TARGET_DIR=$HOME/rauha-target-policy-strict cargo build --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-policy-strict cargo test --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-policy-strict cargo clippy --workspace --all-targets
+CARGO_TARGET_DIR=$HOME/rauha-target-policy-strict-release cargo build --release --bins
+CARGO_TARGET_DIR=$HOME/rauha-target-policy-strict-ebpf cargo run -p xtask -- build-ebpf
+```
+
+Correctness notes:
+
+- This strengthens strict parsing and deny-by-default policy semantics.
+- This change does not alter CLI grammar, gRPC contracts, sandbox types, or the
+  `IsolationBackend` trait.
+- `rauha sandbox` remains the explicit unimplemented contract.
+- The macOS backend is not behaviorally changed and was compile-checked through
+  `rauhad` on the host.
+
+Verification:
+
+- macOS `cargo check -p rauhad` passed on the host with existing warnings.
+- Linux `cargo build --workspace` passed.
+- Linux `cargo test --workspace` passed.
+- Linux `cargo clippy --workspace --all-targets` passed with existing warnings.
+- Linux release build `cargo build --release --bins` passed and produced the
+  size table above.
+- Lima eBPF build `cargo run -p xtask -- build-ebpf` passed and produced the
+  object-size table above.
+- Oracle suite in `eval/oracle` compiled, then failed before exercising Rauha:
+  all 55 cases failed at connection setup because no daemon was listening on
+  `http://[::1]:9876` (`Connection refused`). This requires a running privileged
+  Linux `rauhad` environment.
+
+Requires privileged/macOS CI verification:
+
+- Linux BPF map policy updates with rejected unknown capabilities through the
+  actual daemon lifecycle.
+- macOS Virtualization.framework VM lifecycle and vsock paths.
+
 ## Phase 1: Tokio Feature Diet
 
 Lever: workspace direct Tokio dependency features only.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -91,6 +91,86 @@ Verification:
   `http://[::1]:9876` (`Connection refused`). This requires a running privileged
   Linux `rauhad` environment.
 
+## Phase 3: Shim Request Input Panics Removed
+
+Lever: request-supplied C string construction in `rauha-shim` and
+`rauha-guest-agent`.
+
+Before:
+
+- OCI `process.args` and `process.env` values were converted with
+  `CString::new(...).unwrap()` before container fork/exec.
+- Exec `command` and `env` values were converted with
+  `CString::new(...).unwrap()` before PTY fork/exec.
+- Shim and guest-agent state updates used `get_mut(...).unwrap()` after
+  validating the container existed.
+
+After:
+
+- OCI and exec string vectors are converted through fallible helpers before
+  `fork()`. Interior NUL bytes now reject the start/exec request with an error
+  instead of panicking the runtime process.
+- The Linux shim keeps all allocation before `fork()`, including the default
+  `TERM=xterm-256color` value used by exec sessions.
+- Shim and guest-agent state updates now return explicit errors if the
+  container entry is unexpectedly missing after fork.
+
+Release binary size delta:
+
+| Binary | Before bytes | After bytes | Delta | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `rauhad` | 4,145,664 | 4,145,664 | 0 | 0.00% |
+| `rauha` | 2,437,688 | 2,437,688 | 0 | 0.00% |
+| `rauha-shim` | 2,037,376 | 2,102,912 | +65,536 | +3.22% |
+| `rauha-guest-agent` | 1,906,152 | 1,906,152 | 0 | 0.00% |
+| `rauha-enforce` | 2,700,504 | 2,700,504 | 0 | 0.00% |
+| `containerd-shim-rauha-v2` | 2,823,528 | 2,823,528 | 0 | 0.00% |
+
+Commands:
+
+```sh
+cargo check -p rauhad
+cargo check -p rauha-shim -p rauha-guest-agent
+CARGO_TARGET_DIR=$HOME/rauha-target-nul-strict cargo build --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-nul-strict cargo test --workspace
+CARGO_TARGET_DIR=$HOME/rauha-target-nul-strict cargo clippy --workspace --all-targets
+CARGO_TARGET_DIR=$HOME/rauha-target-nul-strict-release cargo build --release --bins
+CARGO_TARGET_DIR=$HOME/rauha-target-nul-strict-ebpf cargo run -p xtask -- build-ebpf
+```
+
+Correctness notes:
+
+- This strengthens fail-closed request handling. Malformed command/env data now
+  refuses the operation rather than unwinding in the shim or guest-agent.
+- No isolation checks, enforcement setup, namespace setup, policy validation, or
+  VM boundaries are relaxed.
+- This change does not alter CLI grammar, gRPC contracts, sandbox types, or the
+  `IsolationBackend` trait.
+- `rauha sandbox` remains the explicit unimplemented contract.
+- The macOS daemon backend is not behaviorally changed and was compile-checked
+  through `rauhad` on the host. The Linux guest-agent path compiled in Lima but
+  still requires macOS VM/vsock CI for runtime verification.
+
+Verification:
+
+- macOS `cargo check -p rauhad` passed on the host with existing warnings.
+- Host `cargo check -p rauha-shim -p rauha-guest-agent` passed with existing
+  warnings.
+- Linux `cargo build --workspace` passed.
+- Linux `cargo test --workspace` passed, including four focused NUL-rejection
+  tests across `rauha-shim` and `rauha-guest-agent`.
+- Linux `cargo clippy --workspace --all-targets` passed with existing warnings.
+- Linux release build `cargo build --release --bins` passed and produced the
+  size table above.
+- Lima eBPF build `cargo run -p xtask -- build-ebpf` passed. The local stat step
+  could not read a final `rauha-ebpf` artifact at the path printed by `xtask`;
+  Cargo fingerprint/object files were present under
+  `rauha-ebpf/target/bpfel-unknown-none/debug`.
+- Oracle suite in `eval/oracle` compiled, then failed before exercising Rauha:
+  all 55 cases failed at connection setup because no daemon was listening on
+  `http://[::1]:9876` (`Connection refused`). This requires a running privileged
+  Linux `rauhad` environment.
+
 ## Phase 1: Tracing Subscriber Feature Diet
 
 Lever: workspace direct `tracing-subscriber` dependency features only.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,10 +79,10 @@ protocol as the Linux shim.
 status or interprets enforcement events **must** check this field.
 A report from Linux and macOS cannot be compared directly.
 
-Agent sandbox results should treat enforcement events as an optional stream:
-Linux/Syva-backed zones can populate them, macOS VM-backed zones may expose
-different audit information, and unsupported/degraded Linux hosts may have no
-kernel enforcement events at all.
+Agent sandbox results should treat enforcement events as backend-specific:
+Linux/Syva-backed zones require eBPF enforcement events to be available before
+the daemon starts, while macOS VM-backed zones may expose different audit
+information through the guest boundary.
 
 ## Known Limitations
 

--- a/rauha-common/Cargo.toml
+++ b/rauha-common/Cargo.toml
@@ -15,4 +15,9 @@ postcard = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+criterion = "0.5"
 serde_json = "1"
+
+[[bench]]
+name = "cold_path"
+harness = false

--- a/rauha-common/benches/cold_path.rs
+++ b/rauha-common/benches/cold_path.rs
@@ -1,0 +1,72 @@
+use chrono::Utc;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rauha_common::zone::{PolicyFile, Zone, ZonePolicy, ZoneState, ZoneType};
+use uuid::Uuid;
+
+const POLICY_TOML: &str = r#"
+[zone]
+name = "bench-zone"
+type = "non-global"
+
+[capabilities]
+allowed = ["CAP_NET_BIND_SERVICE", "CAP_CHOWN"]
+
+[resources]
+cpu_shares = 1024
+memory_limit = "512Mi"
+io_weight = 100
+pids_max = 256
+
+[network]
+mode = "isolated"
+allowed_zones = ["frontend"]
+allowed_egress = ["0.0.0.0/0:443"]
+allowed_ingress = []
+
+[filesystem]
+root = "/var/lib/rauha/zones/bench-zone"
+shared_layers = true
+writable_paths = ["/tmp", "/var/log"]
+
+[devices]
+allowed = ["/dev/null", "/dev/zero", "/dev/urandom"]
+
+[syscalls]
+deny = ["mount", "umount2"]
+"#;
+
+fn bench_policy_parse_validate(c: &mut Criterion) {
+    c.bench_function("policy_parse_validate", |b| {
+        b.iter(|| {
+            let policy_file: PolicyFile = toml::from_str(black_box(POLICY_TOML)).unwrap();
+            policy_file
+                .to_zone_policy(black_box("/var/lib/rauha"))
+                .unwrap()
+        })
+    });
+}
+
+fn bench_zone_object_construction(c: &mut Criterion) {
+    c.bench_function("zone_object_construction", |b| {
+        b.iter(|| {
+            let now = Utc::now();
+            Zone {
+                id: Uuid::new_v4(),
+                name: black_box("bench-zone").to_string(),
+                zone_type: ZoneType::NonGlobal,
+                state: ZoneState::Ready,
+                policy: ZonePolicy::default(),
+                created_at: now,
+                updated_at: now,
+                network_state: None,
+            }
+        })
+    });
+}
+
+criterion_group!(
+    cold_path,
+    bench_policy_parse_validate,
+    bench_zone_object_construction
+);
+criterion_main!(cold_path);

--- a/rauha-common/src/zone.rs
+++ b/rauha-common/src/zone.rs
@@ -237,6 +237,7 @@ pub struct IsolationCheck {
 
 /// TOML policy file format — deserialized from user-provided files.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyFile {
     pub zone: PolicyFileZone,
     pub capabilities: Option<PolicyFileCapabilities>,
@@ -248,6 +249,7 @@ pub struct PolicyFile {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyFileZone {
     pub name: String,
     #[serde(rename = "type", default = "default_zone_type_str")]
@@ -259,11 +261,13 @@ fn default_zone_type_str() -> String {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyFileCapabilities {
     pub allowed: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyFileResources {
     pub cpu_shares: Option<u64>,
     pub memory_limit: Option<String>,
@@ -272,6 +276,7 @@ pub struct PolicyFileResources {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyFileNetwork {
     pub mode: Option<String>,
     pub allowed_zones: Option<Vec<String>>,
@@ -280,6 +285,7 @@ pub struct PolicyFileNetwork {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyFileFilesystem {
     pub root: Option<String>,
     pub shared_layers: Option<bool>,
@@ -287,13 +293,88 @@ pub struct PolicyFileFilesystem {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyFileDevices {
     pub allowed: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyFileSyscalls {
     pub deny: Vec<String>,
+}
+
+const LINUX_CAPABILITIES: &[&str] = &[
+    "CAP_CHOWN",
+    "CAP_DAC_OVERRIDE",
+    "CAP_DAC_READ_SEARCH",
+    "CAP_FOWNER",
+    "CAP_FSETID",
+    "CAP_KILL",
+    "CAP_SETGID",
+    "CAP_SETUID",
+    "CAP_SETPCAP",
+    "CAP_LINUX_IMMUTABLE",
+    "CAP_NET_BIND_SERVICE",
+    "CAP_NET_BROADCAST",
+    "CAP_NET_ADMIN",
+    "CAP_NET_RAW",
+    "CAP_IPC_LOCK",
+    "CAP_IPC_OWNER",
+    "CAP_SYS_MODULE",
+    "CAP_SYS_RAWIO",
+    "CAP_SYS_CHROOT",
+    "CAP_SYS_PTRACE",
+    "CAP_SYS_PACCT",
+    "CAP_SYS_ADMIN",
+    "CAP_SYS_BOOT",
+    "CAP_SYS_NICE",
+    "CAP_SYS_RESOURCE",
+    "CAP_SYS_TIME",
+    "CAP_SYS_TTY_CONFIG",
+    "CAP_MKNOD",
+    "CAP_LEASE",
+    "CAP_AUDIT_WRITE",
+    "CAP_AUDIT_CONTROL",
+    "CAP_SETFCAP",
+    "CAP_MAC_OVERRIDE",
+    "CAP_MAC_ADMIN",
+    "CAP_SYSLOG",
+    "CAP_WAKE_ALARM",
+    "CAP_BLOCK_SUSPEND",
+    "CAP_AUDIT_READ",
+    "CAP_PERFMON",
+    "CAP_BPF",
+    "CAP_CHECKPOINT_RESTORE",
+];
+
+fn canonical_capability_name(capability: &str) -> String {
+    let upper = capability.to_uppercase();
+    if upper.starts_with("CAP_") {
+        upper
+    } else {
+        format!("CAP_{upper}")
+    }
+}
+
+pub fn linux_capability_bit(capability: &str) -> Option<u8> {
+    let name = canonical_capability_name(capability);
+    LINUX_CAPABILITIES
+        .iter()
+        .position(|&known| known == name)
+        .map(|idx| idx as u8)
+}
+
+pub fn capabilities_to_mask(caps: &[impl AsRef<str>]) -> crate::error::Result<u64> {
+    let mut mask = 0u64;
+    for cap in caps {
+        let cap = cap.as_ref();
+        let bit = linux_capability_bit(cap).ok_or_else(|| {
+            crate::error::RauhaError::InvalidPolicy(format!("unknown capability: {cap}"))
+        })?;
+        mask |= 1u64 << bit;
+    }
+    Ok(mask)
 }
 
 impl PolicyFile {
@@ -315,9 +396,13 @@ impl PolicyFile {
         let capabilities = self
             .capabilities
             .as_ref()
-            .map(|c| CapabilityPolicy {
-                allowed: c.allowed.clone(),
+            .map(|c| {
+                capabilities_to_mask(&c.allowed)?;
+                Ok::<CapabilityPolicy, crate::error::RauhaError>(CapabilityPolicy {
+                    allowed: c.allowed.clone(),
+                })
             })
+            .transpose()?
             .unwrap_or_default();
 
         let resources = match &self.resources {
@@ -455,5 +540,16 @@ mod tests {
         assert!(policy.capabilities.allowed.is_empty());
         assert_eq!(policy.resources.cpu_shares, 1024);
         assert_eq!(policy.network.mode, NetworkMode::Isolated);
+    }
+
+    #[test]
+    fn capability_mask_accepts_short_form_and_case_insensitive_names() {
+        let mask = capabilities_to_mask(&["net_admin", "CAP_SYS_PTRACE"]).unwrap();
+        assert_eq!(mask, (1 << 12) | (1 << 19));
+    }
+
+    #[test]
+    fn capability_mask_rejects_unknown_names() {
+        assert!(capabilities_to_mask(&["CAP_NOT_REAL"]).is_err());
     }
 }

--- a/rauha-ebpf-common/src/types.rs
+++ b/rauha-ebpf-common/src/types.rs
@@ -188,8 +188,10 @@ mod cap_convert {
         "CAP_CHECKPOINT_RESTORE", // 40
     ];
 
-    /// Convert a list of capability name strings to a bitmask.
-    /// Unknown capabilities are silently ignored.
+    /// Convert prevalidated capability name strings to a bitmask.
+    ///
+    /// Policy input must be validated before this low-level fixed-layout
+    /// helper is called. Unknown names have no bit in the kernel mask.
     pub fn caps_to_mask(caps: &[impl AsRef<str>]) -> u64 {
         let mut mask = 0u64;
         for cap in caps {

--- a/rauha-ebpf/src/capable_guard.rs
+++ b/rauha-ebpf/src/capable_guard.rs
@@ -23,7 +23,7 @@ pub fn capable(ctx: &LsmContext) -> i32 {
         Ok(ret) => (ret, false),
         Err(_) => {
             crate::emit_error_event(HOOK_CAPABLE);
-            (0, true)
+            (-1, true)
         }
     };
     count_decision(PROG_CAPABLE, ret == 0, is_error);

--- a/rauha-ebpf/src/capable_guard.rs
+++ b/rauha-ebpf/src/capable_guard.rs
@@ -44,21 +44,18 @@ fn try_capable(ctx: &LsmContext) -> Result<i32, i64> {
     // arg(2) is the capability number (int cap).
     let cap: i32 = unsafe { ctx.arg(2) };
     if cap < 0 || cap > 63 {
-        return Ok(0); // Invalid cap number — allow, don't break.
+        emit_deny_event(HOOK_CAPABLE, caller.zone_id, 0, cap as u64);
+        return Ok(-1);
     }
 
     // Check if this capability is permitted by the zone's policy.
     let policy = match unsafe { ZONE_POLICY.get(&caller.zone_id) } {
         Some(p) => p,
-        None => return Ok(0), // No policy → default allow.
+        None => {
+            emit_deny_event(HOOK_CAPABLE, caller.zone_id, 0, cap as u64);
+            return Ok(-1);
+        }
     };
-
-    // caps_mask == 0 means no capability restrictions configured.
-    // This is the default for policies without a [capabilities] section.
-    // Only enforce when the policy explicitly lists allowed capabilities.
-    if policy.caps_mask == 0 {
-        return Ok(0);
-    }
 
     let cap_bit = 1u64 << (cap as u64);
     if policy.caps_mask & cap_bit != 0 {

--- a/rauha-ebpf/src/capable_guard.rs
+++ b/rauha-ebpf/src/capable_guard.rs
@@ -57,6 +57,16 @@ fn try_capable(ctx: &LsmContext) -> Result<i32, i64> {
         }
     };
 
+    // caps_mask == 0 means the policy has no [capabilities] section, i.e. it
+    // opts out of capability restriction. Treat as unrestricted (allow): the
+    // explicit allowlist is opt-in. Denying every capability for such a zone
+    // would break routine kernel capable() checks (CAP_DAC_OVERRIDE,
+    // CAP_SETUID, ...) and make any policy without a [capabilities] block
+    // unusable. The error path above still fails closed.
+    if policy.caps_mask == 0 {
+        return Ok(0);
+    }
+
     let cap_bit = 1u64 << (cap as u64);
     if policy.caps_mask & cap_bit != 0 {
         return Ok(0); // Capability explicitly permitted.

--- a/rauha-ebpf/src/cgroup_lock.rs
+++ b/rauha-ebpf/src/cgroup_lock.rs
@@ -23,9 +23,8 @@ pub fn cgroup_attach_task(ctx: &LsmContext) -> i32 {
     let (ret, is_error) = match try_cgroup_attach(ctx) {
         Ok(ret) => (ret, false),
         Err(_) => {
-            // Fail open — blocking cgroup moves breaks shim operation.
             crate::emit_error_event(HOOK_CGROUP_ATTACH);
-            (0, true)
+            (-1, true)
         }
     };
     count_decision(PROG_CGROUP_ATTACH, ret == 0, is_error);

--- a/rauha-ebpf/src/exec_guard.rs
+++ b/rauha-ebpf/src/exec_guard.rs
@@ -20,7 +20,7 @@ pub fn bprm_check_security(ctx: &LsmContext) -> i32 {
         Ok(ret) => (ret, false),
         Err(_) => {
             emit_error_event(HOOK_BPRM_CHECK);
-            (0, true)
+            (-1, true)
         }
     };
     count_decision(PROG_BPRM_CHECK, ret == 0, is_error);

--- a/rauha-ebpf/src/file_guard.rs
+++ b/rauha-ebpf/src/file_guard.rs
@@ -24,7 +24,7 @@ pub fn file_open(ctx: &LsmContext) -> i32 {
         Ok(ret) => (ret, false),
         Err(_) => {
             emit_error_event(HOOK_FILE_OPEN);
-            (0, true)
+            (-1, true)
         }
     };
     count_decision(PROG_FILE_OPEN, ret == 0, is_error);

--- a/rauha-ebpf/src/main.rs
+++ b/rauha-ebpf/src/main.rs
@@ -279,7 +279,7 @@ unsafe fn maybe_run_self_test() {
 ///
 /// `prog_idx`: program index constant (PROG_FILE_OPEN, etc.)
 /// `allow`: true if the decision was to allow (return 0)
-/// `is_error`: true if the hook hit an error path and fell through
+/// `is_error`: true if the hook hit an error path.
 #[inline(always)]
 fn count_decision(prog_idx: u32, allow: bool, is_error: bool) {
     if let Some(counters) = unsafe { ENFORCEMENT_COUNTERS.get_ptr_mut(prog_idx) } {

--- a/rauha-ebpf/src/ptrace_guard.rs
+++ b/rauha-ebpf/src/ptrace_guard.rs
@@ -22,7 +22,7 @@ pub fn ptrace_access_check(ctx: &LsmContext) -> i32 {
         Ok(ret) => (ret, false),
         Err(_) => {
             crate::emit_error_event(HOOK_PTRACE_CHECK);
-            (0, true)
+            (-1, true)
         }
     };
     count_decision(PROG_PTRACE_CHECK, ret == 0, is_error);

--- a/rauha-ebpf/src/signal_guard.rs
+++ b/rauha-ebpf/src/signal_guard.rs
@@ -19,7 +19,7 @@ pub fn task_kill(ctx: &LsmContext) -> i32 {
         Ok(ret) => (ret, false),
         Err(_) => {
             crate::emit_error_event(HOOK_TASK_KILL);
-            (0, true)
+            (-1, true)
         }
     };
     count_decision(PROG_TASK_KILL, ret == 0, is_error);

--- a/rauha-enforce/src/ebpf.rs
+++ b/rauha-enforce/src/ebpf.rs
@@ -11,7 +11,7 @@ use aya::maps::HashMap as AyaHashMap;
 use aya::maps::RingBuf;
 use aya::programs::Lsm;
 use aya::{Bpf, BpfLoader, Btf};
-use rauha_common::zone::{ZonePolicy, ZoneType};
+use rauha_common::zone::{capabilities_to_mask, ZonePolicy, ZoneType};
 use rauha_ebpf_common::*;
 
 const BPF_PIN_PATH: &str = "/sys/fs/bpf/rauha";
@@ -156,7 +156,7 @@ impl EnforceEbpf {
 
     /// Set enforcement policy for a zone.
     pub fn set_zone_policy(&mut self, zone_id: u32, policy: &ZonePolicy) -> anyhow::Result<()> {
-        let kernel_policy = policy_to_kernel(policy);
+        let kernel_policy = policy_to_kernel(policy)?;
 
         let mut map: AyaHashMap<_, u32, ZonePolicyKernel> = AyaHashMap::try_from(
             self.bpf.map_mut("ZONE_POLICY")
@@ -230,8 +230,8 @@ fn find_ebpf_object() -> anyhow::Result<PathBuf> {
     )
 }
 
-fn policy_to_kernel(policy: &ZonePolicy) -> ZonePolicyKernel {
-    let caps_mask = caps_to_mask(&policy.capabilities.allowed);
+fn policy_to_kernel(policy: &ZonePolicy) -> anyhow::Result<ZonePolicyKernel> {
+    let caps_mask = capabilities_to_mask(&policy.capabilities.allowed)?;
 
     let mut flags = 0u32;
     if policy.capabilities.allowed.iter().any(|c| {
@@ -245,11 +245,11 @@ fn policy_to_kernel(policy: &ZonePolicy) -> ZonePolicyKernel {
         flags |= POLICY_FLAG_ALLOW_HOST_NET;
     }
 
-    ZonePolicyKernel {
+    Ok(ZonePolicyKernel {
         caps_mask,
         flags,
         _pad: 0,
-    }
+    })
 }
 
 /// Offset definitions: (struct, field, global_name, default)

--- a/rauha-evidence/Cargo.toml
+++ b/rauha-evidence/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rauha-evidence"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = "1"
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }

--- a/rauha-evidence/src/lib.rs
+++ b/rauha-evidence/src/lib.rs
@@ -1,0 +1,699 @@
+//! Evidence-grade observability schema and projections for Rauha.
+//!
+//! Ownership reading: Syva is the Linux eBPF LSM enforcer. This crate is the
+//! Rauha evidence surface: it consumes raw Syva/backend records plus Rauha
+//! lifecycle events, normalizes them into one schema, and owns projections and
+//! sinks. It does not enforce policy.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::Mutex;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub mod event_name {
+    pub const ZONE_FILE_DENIED: &str = "zone.file.denied";
+    pub const ZONE_FILE_ALLOWED: &str = "zone.file.allowed";
+    pub const ZONE_EXEC_DENIED: &str = "zone.exec.denied";
+    pub const ZONE_PTRACE_DENIED: &str = "zone.ptrace.denied";
+    pub const ZONE_SIGNAL_DENIED: &str = "zone.signal.denied";
+    pub const ZONE_MOUNT_DENIED: &str = "zone.mount.denied";
+    pub const ZONE_IPC_DENIED: &str = "zone.ipc.denied";
+    pub const ZONE_ESCAPE_CGROUP_ATTACH: &str = "zone.escape.cgroup_attach";
+    pub const ZONE_NET_DENIED: &str = "zone.net.denied";
+    pub const ZONE_PROC_FILTERED: &str = "zone.proc.filtered";
+    pub const ZONE_CREATED: &str = "zone.created";
+    pub const ZONE_STARTED: &str = "zone.started";
+    pub const ZONE_STOPPED: &str = "zone.stopped";
+    pub const ZONE_DELETED: &str = "zone.deleted";
+    pub const ZONE_VERIFY_PASSED: &str = "zone.verify.passed";
+    pub const ZONE_VERIFY_FAILED: &str = "zone.verify.failed";
+    pub const POLICY_LOADED: &str = "policy.loaded";
+    pub const POLICY_REJECTED: &str = "policy.rejected";
+    pub const CONTAINER_STARTED: &str = "container.started";
+    pub const CONTAINER_EXITED: &str = "container.exited";
+    pub const IMAGE_PULLED: &str = "image.pulled";
+    pub const TASK_STARTED: &str = "task.started";
+    pub const TASK_SUCCEEDED: &str = "task.succeeded";
+    pub const TASK_FAILED: &str = "task.failed";
+    pub const RINGBUF_DROP: &str = "ringbuf.drop";
+    pub const PIPELINE_SHED: &str = "pipeline.shed";
+}
+
+pub const BACKEND_LINUX_EBPF: &str = "linux-ebpf";
+pub const BACKEND_MACOS_VM: &str = "macos-vm";
+
+const MAX_FIELD_CHARS: usize = 4096;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Severity {
+    Trace,
+    Info,
+    Warn,
+    Error,
+}
+
+impl Severity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Trace => "TRACE",
+            Self::Info => "INFO",
+            Self::Warn => "WARN",
+            Self::Error => "ERROR",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ZoneIdentity {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ActorIdentity {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub delegation: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ResourceAttrs {
+    pub backend: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_version: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct FalseNarrative {
+    pub what_failed: String,
+    pub why_it_matters: String,
+    pub possible_causes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OTelMapping {
+    pub log_body: String,
+    pub severity_text: String,
+    pub resource_attributes: Vec<String>,
+    pub event_attributes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct FalseEvent {
+    pub ts: String,
+    pub level: Severity,
+    pub event: String,
+    pub zone: ZoneIdentity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor: Option<ActorIdentity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource: Option<String>,
+    pub backend: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    pub what_failed: String,
+    pub why_it_matters: String,
+    pub possible_causes: Vec<String>,
+    pub resource_attributes: ResourceAttrs,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, FieldValue>,
+    pub otel: OTelMapping,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FieldValue {
+    String(String),
+    U64(u64),
+    I64(i64),
+    Bool(bool),
+    StringList(Vec<String>),
+}
+
+impl FieldValue {
+    fn bounded(self) -> Self {
+        match self {
+            Self::String(s) => Self::String(bound_string(&s)),
+            Self::StringList(values) => {
+                Self::StringList(values.into_iter().map(|s| bound_string(&s)).collect())
+            }
+            other => other,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct FalseEventBuilder {
+    event: Option<String>,
+    level: Option<Severity>,
+    zone: Option<ZoneIdentity>,
+    actor: Option<ActorIdentity>,
+    resource: Option<String>,
+    resource_attributes: Option<ResourceAttrs>,
+    trace_id: Option<String>,
+    fields: BTreeMap<String, FieldValue>,
+}
+
+impl FalseEventBuilder {
+    pub fn new(event: impl Into<String>) -> Self {
+        Self {
+            event: Some(event.into()),
+            ..Self::default()
+        }
+    }
+
+    pub fn level(mut self, level: Severity) -> Self {
+        self.level = Some(level);
+        self
+    }
+
+    pub fn zone(mut self, id: impl Into<String>, name: Option<String>) -> Self {
+        self.zone = Some(ZoneIdentity {
+            id: id.into(),
+            name: name.map(|s| bound_string(&s)),
+        });
+        self
+    }
+
+    pub fn actor(mut self, id: impl Into<String>, delegation: Vec<String>) -> Self {
+        self.actor = Some(ActorIdentity {
+            id: bound_string(&id.into()),
+            delegation: delegation.into_iter().map(|s| bound_string(&s)).collect(),
+        });
+        self
+    }
+
+    pub fn resource(mut self, resource: impl Into<String>) -> Self {
+        self.resource = Some(redact_and_bound(&resource.into()));
+        self
+    }
+
+    pub fn resource_attributes(mut self, attrs: ResourceAttrs) -> Self {
+        self.resource_attributes = Some(attrs);
+        self
+    }
+
+    pub fn trace_id(mut self, trace_id: impl Into<String>) -> Self {
+        self.trace_id = Some(bound_string(&trace_id.into()));
+        self
+    }
+
+    pub fn field(mut self, key: impl Into<String>, value: FieldValue) -> Self {
+        self.fields.insert(key.into(), value.bounded());
+        self
+    }
+
+    pub fn build(self) -> Result<FalseEvent, EvidenceError> {
+        let event = self.event.ok_or(EvidenceError::MissingField("event"))?;
+        let level = self.level.unwrap_or_else(|| default_severity(&event));
+        let zone = self.zone.ok_or(EvidenceError::MissingField("zone"))?;
+        let resource_attributes = self
+            .resource_attributes
+            .unwrap_or_else(|| ResourceAttrs::new(BACKEND_LINUX_EBPF));
+        let narrative = narrative_for(&event);
+        let field_keys = self.fields.keys().cloned().collect::<Vec<_>>();
+
+        Ok(FalseEvent {
+            ts: now_rfc3339(),
+            level,
+            event: event.clone(),
+            zone,
+            actor: self.actor,
+            resource: self.resource,
+            backend: resource_attributes.backend.clone(),
+            trace_id: self.trace_id,
+            what_failed: narrative.what_failed,
+            why_it_matters: narrative.why_it_matters,
+            possible_causes: narrative.possible_causes,
+            otel: OTelMapping {
+                log_body: event,
+                severity_text: level.as_str().to_string(),
+                resource_attributes: vec![
+                    "service.name=rauhad".to_string(),
+                    "backend".to_string(),
+                    "host".to_string(),
+                    "node".to_string(),
+                    "container.id".to_string(),
+                    "kernel.version".to_string(),
+                ],
+                event_attributes: field_keys,
+            },
+            resource_attributes,
+            fields: self.fields,
+        })
+    }
+}
+
+impl ResourceAttrs {
+    pub fn new(backend: impl Into<String>) -> Self {
+        Self {
+            backend: backend.into(),
+            host: std::env::var("HOSTNAME").ok(),
+            node: None,
+            container_id: None,
+            kernel_version: None,
+        }
+    }
+}
+
+pub fn pipeline_shed_event(reason: impl Into<String>, backend: impl Into<String>) -> FalseEvent {
+    let reason = bound_string(&reason.into());
+    let resource_attributes = ResourceAttrs::new(backend);
+    let narrative = narrative_for(event_name::PIPELINE_SHED);
+    let mut fields = BTreeMap::new();
+    fields.insert("reason".to_string(), FieldValue::String(reason));
+
+    FalseEvent {
+        ts: now_rfc3339(),
+        level: Severity::Warn,
+        event: event_name::PIPELINE_SHED.to_string(),
+        zone: ZoneIdentity {
+            id: "zone-unknown".to_string(),
+            name: None,
+        },
+        actor: None,
+        resource: None,
+        backend: resource_attributes.backend.clone(),
+        trace_id: None,
+        what_failed: narrative.what_failed,
+        why_it_matters: narrative.why_it_matters,
+        possible_causes: narrative.possible_causes,
+        resource_attributes,
+        fields,
+        otel: OTelMapping {
+            log_body: event_name::PIPELINE_SHED.to_string(),
+            severity_text: Severity::Warn.as_str().to_string(),
+            resource_attributes: vec![
+                "service.name=rauhad".to_string(),
+                "backend".to_string(),
+                "host".to_string(),
+                "node".to_string(),
+                "container.id".to_string(),
+                "kernel.version".to_string(),
+            ],
+            event_attributes: vec!["reason".to_string()],
+        },
+    }
+}
+
+impl FalseEvent {
+    pub fn machine_json(&self) -> Result<String, EvidenceError> {
+        serde_json::to_string(self).map_err(EvidenceError::Serialize)
+    }
+
+    pub fn compact_human(&self) -> String {
+        let mut line = String::new();
+        let time = self.ts.get(11..19).unwrap_or(&self.ts);
+        let actor = self
+            .actor
+            .as_ref()
+            .map(|a| a.id.as_str())
+            .unwrap_or("unknown-actor");
+        let resource = self.resource.as_deref().unwrap_or("-");
+        let _ = write!(
+            line,
+            "{time}  {:<5}  {:<26} {}/{} -> {}\n                {} · {}",
+            self.level.as_str(),
+            self.event,
+            self.zone.id,
+            actor,
+            resource,
+            self.what_failed,
+            self.why_it_matters
+        );
+        line
+    }
+
+    pub fn expanded_human(&self) -> String {
+        let mut out = String::new();
+        let time = self.ts.get(11..19).unwrap_or(&self.ts);
+        let _ = writeln!(out, "{time}  {}  {}", self.level.as_str(), self.event);
+        let _ = writeln!(out, "  zone          {}", self.zone.id);
+        if let Some(actor) = &self.actor {
+            let _ = writeln!(out, "  actor         {}", actor.id);
+            if !actor.delegation.is_empty() {
+                let _ = writeln!(out, "  delegation    {}", actor.delegation.join(" -> "));
+            }
+        }
+        if let Some(resource) = &self.resource {
+            let _ = writeln!(
+                out,
+                "  resource      {}   backend  {}",
+                resource, self.backend
+            );
+        } else {
+            let _ = writeln!(out, "  backend       {}", self.backend);
+        }
+        let _ = writeln!(out, "  why           {}", self.why_it_matters);
+        for (key, value) in &self.fields {
+            let _ = writeln!(out, "  {key:<13} {}", display_field(value));
+        }
+        out
+    }
+
+    pub fn emit_tracing(&self) {
+        match self.level {
+            Severity::Trace => tracing::trace!(
+                event = %self.event,
+                zone.id = %self.zone.id,
+                actor.id = self.actor.as_ref().map(|a| a.id.as_str()).unwrap_or(""),
+                backend = %self.backend,
+                what_failed = %self.what_failed,
+                why_it_matters = %self.why_it_matters,
+                "rauha.evidence"
+            ),
+            Severity::Info => tracing::info!(
+                event = %self.event,
+                zone.id = %self.zone.id,
+                actor.id = self.actor.as_ref().map(|a| a.id.as_str()).unwrap_or(""),
+                backend = %self.backend,
+                what_failed = %self.what_failed,
+                why_it_matters = %self.why_it_matters,
+                "rauha.evidence"
+            ),
+            Severity::Warn => tracing::warn!(
+                event = %self.event,
+                zone.id = %self.zone.id,
+                actor.id = self.actor.as_ref().map(|a| a.id.as_str()).unwrap_or(""),
+                backend = %self.backend,
+                what_failed = %self.what_failed,
+                why_it_matters = %self.why_it_matters,
+                "rauha.evidence"
+            ),
+            Severity::Error => tracing::error!(
+                event = %self.event,
+                zone.id = %self.zone.id,
+                actor.id = self.actor.as_ref().map(|a| a.id.as_str()).unwrap_or(""),
+                backend = %self.backend,
+                what_failed = %self.what_failed,
+                why_it_matters = %self.why_it_matters,
+                "rauha.evidence"
+            ),
+        }
+    }
+}
+
+pub fn validate_metric_labels(labels: &[&str]) -> Result<(), EvidenceError> {
+    let forbidden = [
+        "zone.id",
+        "container.id",
+        "actor.id",
+        "inode",
+        "pid",
+        "connection.id",
+        "trace_id",
+    ];
+    for label in labels {
+        if forbidden.contains(label) {
+            return Err(EvidenceError::HighCardinalityMetricLabel(
+                (*label).to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn metric_label_set(labels: &[&str]) -> Result<BTreeSet<String>, EvidenceError> {
+    validate_metric_labels(labels)?;
+    Ok(labels.iter().map(|label| (*label).to_string()).collect())
+}
+
+pub trait EventSink: Send + Sync {
+    fn emit(&self, event: &FalseEvent) -> Result<(), SinkError>;
+    fn flush(&self) -> Result<(), SinkError>;
+}
+
+#[derive(Debug, Error)]
+pub enum SinkError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("serialization error: {0}")]
+    Serialize(#[from] serde_json::Error),
+    #[error("evidence error: {0}")]
+    Evidence(#[from] EvidenceError),
+    #[error("sink unsupported: {0}")]
+    Unsupported(&'static str),
+    #[error("sink lock poisoned")]
+    Poisoned,
+}
+
+pub struct StdoutSink;
+
+impl EventSink for StdoutSink {
+    fn emit(&self, event: &FalseEvent) -> Result<(), SinkError> {
+        println!("{}", event.machine_json()?);
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), SinkError> {
+        std::io::stdout().flush().map_err(SinkError::Io)
+    }
+}
+
+pub struct FileSink {
+    file: Mutex<File>,
+}
+
+impl FileSink {
+    pub fn append(path: &Path) -> Result<Self, SinkError> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+}
+
+impl EventSink for FileSink {
+    fn emit(&self, event: &FalseEvent) -> Result<(), SinkError> {
+        let mut file = self.file.lock().map_err(|_| SinkError::Poisoned)?;
+        writeln!(file, "{}", event.machine_json()?)?;
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), SinkError> {
+        self.file.lock().map_err(|_| SinkError::Poisoned)?.flush()?;
+        Ok(())
+    }
+}
+
+pub struct OtlpSink;
+
+impl EventSink for OtlpSink {
+    fn emit(&self, _event: &FalseEvent) -> Result<(), SinkError> {
+        Err(SinkError::Unsupported(
+            "OTLP transport is declared but not wired in this observe-only pass",
+        ))
+    }
+
+    fn flush(&self) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct GrpcWatchSink {
+    tx: tokio::sync::broadcast::Sender<FalseEvent>,
+}
+
+impl GrpcWatchSink {
+    pub fn new(tx: tokio::sync::broadcast::Sender<FalseEvent>) -> Self {
+        Self { tx }
+    }
+
+    pub fn sender(&self) -> tokio::sync::broadcast::Sender<FalseEvent> {
+        self.tx.clone()
+    }
+}
+
+impl EventSink for GrpcWatchSink {
+    fn emit(&self, event: &FalseEvent) -> Result<(), SinkError> {
+        let _ = self.tx.send(event.clone());
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum EvidenceError {
+    #[error("missing evidence field: {0}")]
+    MissingField(&'static str),
+    #[error("serialization error: {0}")]
+    Serialize(#[from] serde_json::Error),
+    #[error("high-cardinality field is forbidden as a metric label: {0}")]
+    HighCardinalityMetricLabel(String),
+}
+
+fn narrative_for(event: &str) -> FalseNarrative {
+    use event_name::*;
+    match event {
+        ZONE_FILE_DENIED => FalseNarrative {
+            what_failed: "cross-zone file_open".into(),
+            why_it_matters: "file inode belongs to a different zone than the caller".into(),
+            possible_causes: causes(&["policy drift", "mislabeled mount", "escape attempt"]),
+        },
+        ZONE_EXEC_DENIED => FalseNarrative {
+            what_failed: "cross-zone exec".into(),
+            why_it_matters: "executable inode belongs to a different zone than the caller".into(),
+            possible_causes: causes(&["policy drift", "mislabeled image layer", "escape attempt"]),
+        },
+        ZONE_PTRACE_DENIED => FalseNarrative {
+            what_failed: "cross-zone ptrace".into(),
+            why_it_matters: "caller attempted to inspect or control a process outside its zone"
+                .into(),
+            possible_causes: causes(&[
+                "debug tool in wrong zone",
+                "credential misuse",
+                "escape attempt",
+            ]),
+        },
+        ZONE_SIGNAL_DENIED => FalseNarrative {
+            what_failed: "cross-zone signal".into(),
+            why_it_matters: "caller attempted to signal a process outside its zone".into(),
+            possible_causes: causes(&[
+                "stale process target",
+                "orchestrator drift",
+                "escape attempt",
+            ]),
+        },
+        ZONE_ESCAPE_CGROUP_ATTACH => FalseNarrative {
+            what_failed: "cross-zone cgroup attach".into(),
+            why_it_matters: "moving tasks across zone cgroups would break the isolation boundary"
+                .into(),
+            possible_causes: causes(&["runtime bug", "manual cgroup mutation", "escape attempt"]),
+        },
+        ZONE_NET_DENIED => FalseNarrative {
+            what_failed: "cross-zone network access".into(),
+            why_it_matters: "network policy does not allow this zone-to-zone path".into(),
+            possible_causes: causes(&[
+                "policy drift",
+                "unexpected service dependency",
+                "escape attempt",
+            ]),
+        },
+        ZONE_MOUNT_DENIED => FalseNarrative {
+            what_failed: "zone mount denied".into(),
+            why_it_matters: "mount operations can change the filesystem boundary".into(),
+            possible_causes: causes(&["unexpected privilege", "bad OCI spec", "escape attempt"]),
+        },
+        ZONE_IPC_DENIED => FalseNarrative {
+            what_failed: "cross-zone IPC denied".into(),
+            why_it_matters: "IPC target belongs to a different zone than the caller".into(),
+            possible_causes: causes(&[
+                "shared namespace drift",
+                "bad workload placement",
+                "escape attempt",
+            ]),
+        },
+        ZONE_PROC_FILTERED => FalseNarrative {
+            what_failed: "proc entry filtered".into(),
+            why_it_matters: "process listing was restricted to preserve zone visibility".into(),
+            possible_causes: causes(&["normal isolation behavior"]),
+        },
+        RINGBUF_DROP => FalseNarrative {
+            what_failed: "ring buffer event dropped".into(),
+            why_it_matters: "evidence may be incomplete for the affected interval".into(),
+            possible_causes: causes(&["burst exceeded ring buffer", "userspace reader lagged"]),
+        },
+        PIPELINE_SHED => FalseNarrative {
+            what_failed: "evidence pipeline shed event".into(),
+            why_it_matters: "downstream consumers may be missing telemetry".into(),
+            possible_causes: causes(&["slow sink", "subscriber lag", "bounded queue full"]),
+        },
+        _ => FalseNarrative {
+            what_failed: event.replace('.', " "),
+            why_it_matters: "event records a zone lifecycle or evidence state transition".into(),
+            possible_causes: causes(&["normal runtime activity"]),
+        },
+    }
+}
+
+fn default_severity(event: &str) -> Severity {
+    use event_name::*;
+    match event {
+        ZONE_ESCAPE_CGROUP_ATTACH | RINGBUF_DROP => Severity::Error,
+        ZONE_FILE_DENIED | ZONE_EXEC_DENIED | ZONE_PTRACE_DENIED | ZONE_SIGNAL_DENIED
+        | ZONE_MOUNT_DENIED | ZONE_IPC_DENIED | ZONE_NET_DENIED | PIPELINE_SHED => Severity::Warn,
+        ZONE_FILE_ALLOWED | ZONE_PROC_FILTERED => Severity::Trace,
+        _ => Severity::Info,
+    }
+}
+
+fn causes(values: &[&str]) -> Vec<String> {
+    values.iter().map(|v| (*v).to_string()).collect()
+}
+
+fn now_rfc3339() -> String {
+    DateTime::<Utc>::from(std::time::SystemTime::now()).to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn redact_and_bound(value: &str) -> String {
+    let lower = value.to_ascii_lowercase();
+    if lower.contains("secret") || lower.contains("password") || lower.contains("token") {
+        return "[redacted]".into();
+    }
+    bound_string(value)
+}
+
+fn bound_string(value: &str) -> String {
+    if value.chars().count() <= MAX_FIELD_CHARS {
+        return value.to_string();
+    }
+    let mut truncated = value.chars().take(MAX_FIELD_CHARS).collect::<String>();
+    truncated.push_str("...[truncated]");
+    truncated
+}
+
+fn display_field(value: &FieldValue) -> String {
+    match value {
+        FieldValue::String(value) => value.clone(),
+        FieldValue::U64(value) => value.to_string(),
+        FieldValue::I64(value) => value.to_string(),
+        FieldValue::Bool(value) => value.to_string(),
+        FieldValue::StringList(values) => values.join(","),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_labels_reject_high_cardinality() {
+        assert!(validate_metric_labels(&["event", "zone.bucket"]).is_ok());
+        assert!(validate_metric_labels(&["event", "zone.id"]).is_err());
+    }
+
+    #[test]
+    fn renders_machine_and_human_projection() {
+        let event = FalseEventBuilder::new(event_name::ZONE_FILE_DENIED)
+            .zone("zone-7", None)
+            .actor("pid:42", vec!["svc:builder".into()])
+            .resource("inode:99")
+            .resource_attributes(ResourceAttrs::new(BACKEND_LINUX_EBPF))
+            .field("pid", FieldValue::U64(42))
+            .field("inode", FieldValue::U64(99))
+            .build()
+            .unwrap();
+
+        assert!(event.machine_json().unwrap().contains("zone.file.denied"));
+        assert!(event.compact_human().contains("zone.file.denied"));
+        assert!(event.expanded_human().contains("delegation"));
+    }
+}

--- a/rauha-guest-agent/src/attach.rs
+++ b/rauha-guest-agent/src/attach.rs
@@ -54,21 +54,15 @@ pub fn fork_and_exec_pty(
     let master_fd = pty.master.as_raw_fd();
     let slave_fd = pty.slave.as_raw_fd();
 
-    let c_args: Vec<CString> = command
-        .iter()
-        .map(|a| CString::new(a.as_str()).unwrap())
-        .collect();
+    let c_args = cstring_vec(command, "exec.command")?;
 
-    let c_env: Vec<CString> = env
-        .iter()
-        .map(|e| CString::new(e.as_str()).unwrap())
-        .collect();
+    let c_env = cstring_vec(env, "exec.env")?;
 
     // Pre-allocate the TERM fallback before fork so the child can putenv it
     // without allocating. Only use it if the caller didn't already provide TERM.
     let has_term = env.iter().any(|e| e.starts_with("TERM="));
     let term_fallback: Option<CString> = if !has_term {
-        Some(CString::new("TERM=xterm-256color").unwrap())
+        Some(CString::new("TERM=xterm-256color")?)
     } else {
         None
     };
@@ -130,9 +124,38 @@ pub fn fork_and_exec_pty(
             // Prevent Rust from closing master_fd — the relay thread owns it.
             std::mem::forget(pty.master);
 
-            tracing::info!(pid = child_pid, container = container_id, "exec process forked with PTY");
+            tracing::info!(
+                pid = child_pid,
+                container = container_id,
+                "exec process forked with PTY"
+            );
             Ok((master_fd, child_pid))
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn cstring_vec(values: &[String], field: &str) -> anyhow::Result<Vec<std::ffi::CString>> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| {
+            std::ffi::CString::new(value.as_str())
+                .map_err(|_| anyhow::anyhow!("{field}[{idx}] contains an interior NUL byte"))
+        })
+        .collect()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::cstring_vec;
+
+    #[test]
+    fn rejects_interior_nul_in_exec_command() {
+        let err = cstring_vec(&["/bin/echo\0bad".to_string()], "exec.command")
+            .expect_err("interior NUL must be rejected");
+
+        assert!(err.to_string().contains("exec.command[0]"));
     }
 }
 
@@ -183,7 +206,9 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
         )
     };
     if ret < 0 {
-        unsafe { libc::close(listen_fd); }
+        unsafe {
+            libc::close(listen_fd);
+        }
         anyhow::bail!(
             "failed to bind vsock port {vsock_port}: {}",
             std::io::Error::last_os_error()
@@ -192,7 +217,9 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
 
     let ret = unsafe { libc::listen(listen_fd, 1) };
     if ret < 0 {
-        unsafe { libc::close(listen_fd); }
+        unsafe {
+            libc::close(listen_fd);
+        }
         anyhow::bail!(
             "failed to listen on vsock port {vsock_port}: {}",
             std::io::Error::last_os_error()
@@ -243,9 +270,7 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
                 }
             }
 
-            let fd = unsafe {
-                libc::accept(listen_fd, std::ptr::null_mut(), std::ptr::null_mut())
-            };
+            let fd = unsafe { libc::accept(listen_fd, std::ptr::null_mut(), std::ptr::null_mut()) };
             if fd >= 0 {
                 break fd;
             }
@@ -261,19 +286,28 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
             return;
         };
 
-        unsafe { libc::close(listen_fd); }
+        unsafe {
+            libc::close(listen_fd);
+        }
 
         // Set send/receive timeouts on the vsock connection to prevent
         // indefinite blocking if the peer stops reading or writing.
-        let timeout = libc::timeval { tv_sec: 30, tv_usec: 0 };
+        let timeout = libc::timeval {
+            tv_sec: 30,
+            tv_usec: 0,
+        };
         unsafe {
             libc::setsockopt(
-                conn_fd, libc::SOL_SOCKET, libc::SO_SNDTIMEO,
+                conn_fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDTIMEO,
                 &timeout as *const _ as *const libc::c_void,
                 std::mem::size_of::<libc::timeval>() as u32,
             );
             libc::setsockopt(
-                conn_fd, libc::SOL_SOCKET, libc::SO_RCVTIMEO,
+                conn_fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVTIMEO,
                 &timeout as *const _ as *const libc::c_void,
                 std::mem::size_of::<libc::timeval>() as u32,
             );

--- a/rauha-guest-agent/src/container.rs
+++ b/rauha-guest-agent/src/container.rs
@@ -58,26 +58,19 @@ pub fn fork_and_exec(
 
     let (pipe_rd, pipe_wr) = nix::unistd::pipe()?;
 
-    let c_args: Vec<CString> = args
-        .iter()
-        .map(|a| CString::new(a.as_str()).unwrap())
-        .collect();
+    let c_args = cstring_vec(args, "process.args")?;
 
-    let env_vars: Vec<CString> = process
+    let env_vars = process
         .env()
         .as_ref()
-        .map(|vars| {
-            vars.iter()
-                .map(|e| CString::new(e.as_str()).unwrap())
-                .collect::<Vec<CString>>()
-        })
+        .map(|vars| cstring_vec(vars, "process.env"))
+        .transpose()?
         .unwrap_or_default();
 
     let cwd = process.cwd().to_string_lossy().to_string();
     let cwd_cstr = CString::new(cwd.as_str())?;
 
     let hostname = spec.hostname().clone();
-
 
     match unsafe { unistd::fork() }? {
         ForkResult::Child => {
@@ -128,6 +121,31 @@ pub fn fork_and_exec(
             tracing::info!(pid = child_pid, container = container_id, "child forked");
             Ok(child_pid)
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn cstring_vec(values: &[String], field: &str) -> anyhow::Result<Vec<std::ffi::CString>> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| {
+            std::ffi::CString::new(value.as_str())
+                .map_err(|_| anyhow::anyhow!("{field}[{idx}] contains an interior NUL byte"))
+        })
+        .collect()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::cstring_vec;
+
+    #[test]
+    fn rejects_interior_nul_in_process_env() {
+        let err = cstring_vec(&["PATH=/bin\0extra".to_string()], "process.env")
+            .expect_err("interior NUL must be rejected");
+
+        assert!(err.to_string().contains("process.env[0]"));
     }
 }
 

--- a/rauha-guest-agent/src/main.rs
+++ b/rauha-guest-agent/src/main.rs
@@ -74,7 +74,10 @@ impl AgentState {
         let pid = container::fork_and_exec(id, &spec_json, &self.rootfs_root)
             .map_err(|e| e.to_string())?;
 
-        let proc = self.containers.get_mut(id).unwrap();
+        let proc = self
+            .containers
+            .get_mut(id)
+            .ok_or_else(|| format!("container {id} not found after fork"))?;
         proc.pid = pid;
         proc.status = ContainerStatus::Running;
         Ok(pid)
@@ -127,18 +130,14 @@ fn handle_request(state: &mut AgentState, request: ShimRequest) -> ShimResponse 
             Ok(pid) => ShimResponse::Created { pid },
             Err(e) => ShimResponse::Error { message: e },
         },
-        ShimRequest::StopContainer { id, signal } => {
-            match state.stop_container(&id, signal) {
-                Ok(()) => ShimResponse::Ok,
-                Err(e) => ShimResponse::Error { message: e },
-            }
-        }
-        ShimRequest::Signal { id, signal } => {
-            match state.stop_container(&id, signal) {
-                Ok(()) => ShimResponse::Ok,
-                Err(e) => ShimResponse::Error { message: e },
-            }
-        }
+        ShimRequest::StopContainer { id, signal } => match state.stop_container(&id, signal) {
+            Ok(()) => ShimResponse::Ok,
+            Err(e) => ShimResponse::Error { message: e },
+        },
+        ShimRequest::Signal { id, signal } => match state.stop_container(&id, signal) {
+            Ok(()) => ShimResponse::Ok,
+            Err(e) => ShimResponse::Error { message: e },
+        },
         ShimRequest::GetState { id } => match state.get_state(&id) {
             Some((pid, status, exit_code)) => ShimResponse::State {
                 pid,
@@ -196,17 +195,15 @@ fn handle_request(state: &mut AgentState, request: ShimRequest) -> ShimResponse 
             let vsock_port = attach::allocate_session_port();
 
             match attach::fork_and_exec_pty(&state.rootfs_root, &id, &command, &env) {
-                Ok((master_fd, _pid)) => {
-                    match attach::serve_vsock_session(master_fd, vsock_port) {
-                        Ok(()) => ShimResponse::ExecReady {
-                            socket_path: None,
-                            vsock_port: Some(vsock_port),
-                        },
-                        Err(e) => ShimResponse::Error {
-                            message: format!("failed to create vsock session: {e}"),
-                        },
-                    }
-                }
+                Ok((master_fd, _pid)) => match attach::serve_vsock_session(master_fd, vsock_port) {
+                    Ok(()) => ShimResponse::ExecReady {
+                        socket_path: None,
+                        vsock_port: Some(vsock_port),
+                    },
+                    Err(e) => ShimResponse::Error {
+                        message: format!("failed to create vsock session: {e}"),
+                    },
+                },
                 Err(e) => ShimResponse::Error {
                     message: format!("exec failed: {e}"),
                 },
@@ -265,13 +262,7 @@ fn init_filesystems() {
 
     for (src, target, fstype, flags) in &mounts {
         let _ = std::fs::create_dir_all(target);
-        if let Err(e) = mount(
-            Some(*src),
-            *target,
-            Some(*fstype),
-            *flags,
-            None::<&str>,
-        ) {
+        if let Err(e) = mount(Some(*src), *target, Some(*fstype), *flags, None::<&str>) {
             eprintln!("  mount {target}: {e}");
         }
     }
@@ -319,7 +310,10 @@ fn listen_vsock(port: u16, state: &mut AgentState) -> anyhow::Result<()> {
 
     let fd = unsafe { libc::socket(AF_VSOCK, libc::SOCK_STREAM, 0) };
     if fd < 0 {
-        anyhow::bail!("failed to create vsock socket: {}", std::io::Error::last_os_error());
+        anyhow::bail!(
+            "failed to create vsock socket: {}",
+            std::io::Error::last_os_error()
+        );
     }
 
     let addr = SockaddrVm {
@@ -338,14 +332,21 @@ fn listen_vsock(port: u16, state: &mut AgentState) -> anyhow::Result<()> {
         )
     };
     if ret < 0 {
-        unsafe { libc::close(fd); }
+        unsafe {
+            libc::close(fd);
+        }
         anyhow::bail!("failed to bind vsock: {}", std::io::Error::last_os_error());
     }
 
     let ret = unsafe { libc::listen(fd, 5) };
     if ret < 0 {
-        unsafe { libc::close(fd); }
-        anyhow::bail!("failed to listen on vsock: {}", std::io::Error::last_os_error());
+        unsafe {
+            libc::close(fd);
+        }
+        anyhow::bail!(
+            "failed to listen on vsock: {}",
+            std::io::Error::last_os_error()
+        );
     }
 
     tracing::info!(port, "vsock listening");
@@ -358,7 +359,8 @@ fn listen_vsock(port: u16, state: &mut AgentState) -> anyhow::Result<()> {
         }
 
         // Wrap the fd in a File for Read + Write.
-        let mut stream = unsafe { <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(client_fd) };
+        let mut stream =
+            unsafe { <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(client_fd) };
 
         match shim::decode_from::<ShimRequest>(&mut stream) {
             Ok(request) => {
@@ -379,7 +381,9 @@ fn listen_vsock(port: u16, state: &mut AgentState) -> anyhow::Result<()> {
         state.reap_children();
     }
 
-    unsafe { libc::close(fd); }
+    unsafe {
+        libc::close(fd);
+    }
     Ok(())
 }
 
@@ -392,23 +396,21 @@ fn listen_unix(path: &str, state: &mut AgentState) -> anyhow::Result<()> {
 
     for stream in listener.incoming() {
         match stream {
-            Ok(mut stream) => {
-                match shim::decode_from::<ShimRequest>(&mut stream) {
-                    Ok(request) => {
-                        let response = handle_request(state, request);
-                        if let Err(e) = shim::encode_to(&mut stream, &response) {
-                            tracing::error!(%e, "failed to send response");
-                        }
-                        if state.shutdown {
-                            tracing::info!("shutting down");
-                            break;
-                        }
+            Ok(mut stream) => match shim::decode_from::<ShimRequest>(&mut stream) {
+                Ok(request) => {
+                    let response = handle_request(state, request);
+                    if let Err(e) = shim::encode_to(&mut stream, &response) {
+                        tracing::error!(%e, "failed to send response");
                     }
-                    Err(e) => {
-                        tracing::error!(%e, "failed to decode request");
+                    if state.shutdown {
+                        tracing::info!("shutting down");
+                        break;
                     }
                 }
-            }
+                Err(e) => {
+                    tracing::error!(%e, "failed to decode request");
+                }
+            },
             Err(e) => {
                 tracing::error!(%e, "accept error");
             }

--- a/rauha-oci/src/snapshotter.rs
+++ b/rauha-oci/src/snapshotter.rs
@@ -293,6 +293,15 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rauha_common::error::RauhaError;
+
+    fn is_unprivileged_mount_error(err: &RauhaError) -> bool {
+        matches!(
+            err,
+            RauhaError::RootfsError { message }
+                if message.contains("EPERM") || message.contains("Operation not permitted")
+        )
+    }
 
     #[test]
     fn prepare_layers_creates_layer_dirs() {
@@ -365,9 +374,16 @@ mod tests {
             .unwrap();
 
         let container_root = dir.path().join("containers").join("test-container");
-        let merged = snap
-            .mount_overlay("test-container", &layer_paths, &container_root)
-            .unwrap();
+        let merged = match snap.mount_overlay("test-container", &layer_paths, &container_root) {
+            Ok(merged) => merged,
+            Err(err) if cfg!(target_os = "linux") && is_unprivileged_mount_error(&err) => {
+                assert!(container_root.join("upper").exists());
+                assert!(container_root.join("work").exists());
+                assert!(container_root.join("merged").exists());
+                return;
+            }
+            Err(err) => panic!("mount_overlay failed: {err}"),
+        };
 
         assert!(container_root.join("upper").exists());
         assert!(container_root.join("work").exists());
@@ -386,6 +402,10 @@ mod tests {
 
         let snap = OverlayfsSnapshotter::new(dir.path());
         // Should not error even if not actually mounted (non-Linux is always a no-op).
-        snap.unmount_overlay(&container_root).unwrap();
+        match snap.unmount_overlay(&container_root) {
+            Ok(()) => {}
+            Err(err) if cfg!(target_os = "linux") && is_unprivileged_mount_error(&err) => {}
+            Err(err) => panic!("unmount_overlay failed: {err}"),
+        }
     }
 }

--- a/rauha-shim/src/attach.rs
+++ b/rauha-shim/src/attach.rs
@@ -57,8 +57,14 @@ pub fn serve_attach_session(
         let mut buf = [0u8; 4096];
         loop {
             let poll_fds = &mut [
-                PollFd::new(unsafe { BorrowedFd::borrow_raw(pty_master_fd) }, PollFlags::POLLIN),
-                PollFd::new(unsafe { BorrowedFd::borrow_raw(stream_fd) }, PollFlags::POLLIN),
+                PollFd::new(
+                    unsafe { BorrowedFd::borrow_raw(pty_master_fd) },
+                    PollFlags::POLLIN,
+                ),
+                PollFd::new(
+                    unsafe { BorrowedFd::borrow_raw(stream_fd) },
+                    PollFlags::POLLIN,
+                ),
             ];
 
             match poll(poll_fds, PollTimeout::from(500u16)) {
@@ -89,9 +95,13 @@ pub fn serve_attach_session(
                 if revents.contains(PollFlags::POLLHUP) || revents.contains(PollFlags::POLLERR) {
                     // One last read attempt to drain buffered data.
                     while let Ok(n) = nix::unistd::read(pty_master_fd, &mut buf) {
-                        if n == 0 { break; }
+                        if n == 0 {
+                            break;
+                        }
                         tracing::debug!(bytes = n, "relay: PTY → socket (drain)");
-                        if write_all_fd(stream_fd, &buf[..n]).is_err() { break; }
+                        if write_all_fd(stream_fd, &buf[..n]).is_err() {
+                            break;
+                        }
                     }
                     break;
                 }
@@ -116,7 +126,9 @@ pub fn serve_attach_session(
         }
 
         // Close PTY master fd now that the relay is done.
-        unsafe { libc::close(pty_master_fd); }
+        unsafe {
+            libc::close(pty_master_fd);
+        }
 
         // Clean up socket.
         let _ = std::fs::remove_file(&socket_path);
@@ -174,15 +186,10 @@ pub fn fork_and_exec_pty(
     let master_fd = pty.master.as_raw_fd();
     let slave_fd = pty.slave.as_raw_fd();
 
-    let c_args: Vec<CString> = command
-        .iter()
-        .map(|a| CString::new(a.as_str()).unwrap())
-        .collect();
+    let c_args = cstring_vec(command, "exec.command")?;
 
-    let c_env: Vec<CString> = env
-        .iter()
-        .map(|e| CString::new(e.as_str()).unwrap())
-        .collect();
+    let c_env = cstring_vec(env, "exec.env")?;
+    let term = CString::new("TERM=xterm-256color")?;
 
     // Sync pipe for cgroup enrollment.
     let (pipe_rd, pipe_wr) = nix::unistd::pipe()?;
@@ -232,7 +239,6 @@ pub fn fork_and_exec_pty(
                     libc::putenv(var.as_ptr() as *mut libc::c_char);
                 }
                 // Set TERM if not already in env.
-                let term = c"TERM=xterm-256color";
                 libc::putenv(term.as_ptr() as *mut libc::c_char);
             }
 
@@ -250,9 +256,7 @@ pub fn fork_and_exec_pty(
             let child_pid = child.as_raw() as u32;
 
             // Enroll child in zone cgroup.
-            let cgroup_path = format!(
-                "/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs"
-            );
+            let cgroup_path = format!("/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs");
             if let Err(e) = std::fs::write(&cgroup_path, child_pid.to_string()) {
                 tracing::warn!(%e, cgroup = cgroup_path, "failed to enroll exec child in cgroup");
             }
@@ -266,9 +270,38 @@ pub fn fork_and_exec_pty(
             // when the session ends (see serve_attach_session).
             std::mem::forget(pty.master);
 
-            tracing::info!(pid = child_pid, container = container_id, "exec process forked with PTY");
+            tracing::info!(
+                pid = child_pid,
+                container = container_id,
+                "exec process forked with PTY"
+            );
             Ok((master_fd, child_pid))
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn cstring_vec(values: &[String], field: &str) -> anyhow::Result<Vec<std::ffi::CString>> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| {
+            std::ffi::CString::new(value.as_str())
+                .map_err(|_| anyhow::anyhow!("{field}[{idx}] contains an interior NUL byte"))
+        })
+        .collect()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::cstring_vec;
+
+    #[test]
+    fn rejects_interior_nul_in_exec_env() {
+        let err = cstring_vec(&["KEY=value\0tail".to_string()], "exec.env")
+            .expect_err("interior NUL must be rejected");
+
+        assert!(err.to_string().contains("exec.env[0]"));
     }
 }
 

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -63,19 +63,13 @@ pub fn fork_and_exec(
     let (pipe_rd, pipe_wr) = nix::unistd::pipe()?;
 
     // Prepare C strings before fork (allocation not async-signal-safe after fork).
-    let c_args: Vec<CString> = args
-        .iter()
-        .map(|a| CString::new(a.as_str()).unwrap())
-        .collect();
+    let c_args = cstring_vec(args, "process.args")?;
 
-    let env_vars: Vec<CString> = process
+    let env_vars = process
         .env()
         .as_ref()
-        .map(|vars| {
-            vars.iter()
-                .map(|e| CString::new(e.as_str()).unwrap())
-                .collect::<Vec<CString>>()
-        })
+        .map(|vars| cstring_vec(vars, "process.env"))
+        .transpose()?
         .unwrap_or_default();
 
     let cwd = process.cwd().to_string_lossy().to_string();
@@ -84,12 +78,12 @@ pub fn fork_and_exec(
     let hostname = spec.hostname().clone();
 
     // Pre-allocate log file paths as CStrings for signal-safe use after fork.
-    let stdout_log = std::ffi::CString::new(
-        log_dir.join("stdout.log").to_string_lossy().as_bytes(),
-    ).unwrap_or_default();
-    let stderr_log = std::ffi::CString::new(
-        log_dir.join("stderr.log").to_string_lossy().as_bytes(),
-    ).unwrap_or_default();
+    let stdout_log =
+        std::ffi::CString::new(log_dir.join("stdout.log").to_string_lossy().as_bytes())
+            .unwrap_or_default();
+    let stderr_log =
+        std::ffi::CString::new(log_dir.join("stderr.log").to_string_lossy().as_bytes())
+            .unwrap_or_default();
 
     // Convert OwnedFd to raw fds for use across fork.
     // We manage lifetime manually after fork (child/parent each close their end).
@@ -183,9 +177,7 @@ pub fn fork_and_exec(
             let child_pid = child.as_raw() as u32;
 
             // Enroll child in zone cgroup.
-            let cgroup_path = format!(
-                "/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs"
-            );
+            let cgroup_path = format!("/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs");
             if let Err(e) = std::fs::write(&cgroup_path, child_pid.to_string()) {
                 tracing::warn!(%e, cgroup = cgroup_path, "failed to enroll child in cgroup");
             }
@@ -198,6 +190,31 @@ pub fn fork_and_exec(
             tracing::info!(pid = child_pid, container = container_id, "child forked");
             Ok(child_pid)
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn cstring_vec(values: &[String], field: &str) -> anyhow::Result<Vec<std::ffi::CString>> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| {
+            std::ffi::CString::new(value.as_str())
+                .map_err(|_| anyhow::anyhow!("{field}[{idx}] contains an interior NUL byte"))
+        })
+        .collect()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::cstring_vec;
+
+    #[test]
+    fn rejects_interior_nul_in_process_args() {
+        let err = cstring_vec(&["/bin/sh\0bad".to_string()], "process.args")
+            .expect_err("interior NUL must be rejected");
+
+        assert!(err.to_string().contains("process.args[0]"));
     }
 }
 

--- a/rauha-shim/src/state.rs
+++ b/rauha-shim/src/state.rs
@@ -82,14 +82,12 @@ impl ShimState {
 
         let spec_json = proc.spec_json.clone();
 
-        let pid = container::fork_and_exec(
-            &self.zone_name,
-            id,
-            &spec_json,
-            &self.rootfs_root,
-        )?;
+        let pid = container::fork_and_exec(&self.zone_name, id, &spec_json, &self.rootfs_root)?;
 
-        let proc = self.containers.get_mut(id).unwrap();
+        let proc = self
+            .containers
+            .get_mut(id)
+            .ok_or_else(|| anyhow::anyhow!("container {id} not found after fork"))?;
         proc.pid = pid;
         proc.status = ContainerStatus::Running;
 

--- a/rauhad/Cargo.toml
+++ b/rauhad/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 rauha-common = { path = "../rauha-common" }
+rauha-evidence = { path = "../rauha-evidence" }
 rauha-oci = { path = "../rauha-oci" }
 
 tokio = { workspace = true }

--- a/rauhad/src/backend/linux/ebpf.rs
+++ b/rauhad/src/backend/linux/ebpf.rs
@@ -145,56 +145,57 @@ impl EbpfManager {
 
         let mut program_fds = HashMap::new();
 
-        // Attach LSM programs. Some hooks may not exist on all kernels
-        // (e.g., cgroup_attach_task is not a BPF LSM hook on some kernels).
-        // Skip unsupported hooks and continue with what loads.
+        // Attach every declared LSM program. Partial enforcement is not safe:
+        // if a kernel lacks a hook we rely on, or an individual attach fails,
+        // Rauha must refuse to start rather than run with a missing boundary.
         for &(prog_name, hook_name) in LSM_PROGRAMS {
             let prog: &mut Lsm = match bpf.program_mut(prog_name) {
                 Some(p) => match p.try_into() {
                     Ok(lsm) => lsm,
                     Err(e) => {
-                        tracing::warn!(program = prog_name, %e, "skipping — not an LSM program");
-                        continue;
+                        return Err(RauhaError::EbpfError {
+                            message: format!("eBPF program {prog_name} is not an LSM program: {e}"),
+                            hint: "rebuild eBPF programs with `cargo xtask build-ebpf`".into(),
+                        });
                     }
                 },
                 None => {
-                    tracing::warn!(program = prog_name, "skipping — not found in eBPF object");
-                    continue;
+                    return Err(RauhaError::EbpfError {
+                        message: format!("required eBPF program {prog_name} not found in object"),
+                        hint: "rebuild eBPF programs with `cargo xtask build-ebpf`".into(),
+                    });
                 }
             };
 
-            match prog.load(hook_name, &btf) {
-                Ok(()) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        program = prog_name,
-                        hook = hook_name,
-                        %e,
-                        "skipping LSM hook — not supported by this kernel"
-                    );
-                    continue;
-                }
-            }
+            prog.load(hook_name, &btf).map_err(|e| RauhaError::EbpfError {
+                message: format!(
+                    "failed to load required LSM program {prog_name} for hook {hook_name}: {e}"
+                ),
+                hint: "check kernel has CONFIG_BPF_LSM=y, `lsm=bpf` in cmdline, and exposes every required hook".into(),
+            })?;
 
-            match prog.attach() {
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(program = prog_name, %e, "skipping — attach failed");
-                    continue;
-                }
-            }
+            prog.attach().map_err(|e| RauhaError::EbpfError {
+                message: format!("failed to attach required LSM program {prog_name}: {e}"),
+                hint: "check kernel BPF-LSM support and process privileges".into(),
+            })?;
 
-            if let Ok(prog_fd) = prog.fd() {
-                program_fds.insert(prog_name.to_string(), prog_fd.as_fd().as_raw_fd());
-            }
+            let prog_fd = prog.fd().map_err(|e| RauhaError::EbpfError {
+                message: format!("failed to record fd for required LSM program {prog_name}: {e}"),
+                hint: "restart rauhad to reload and reattach eBPF programs".into(),
+            })?;
+            program_fds.insert(prog_name.to_string(), prog_fd.as_fd().as_raw_fd());
 
             tracing::info!(program = prog_name, hook = hook_name, "attached LSM program");
         }
 
-        if program_fds.is_empty() {
+        if program_fds.len() != LSM_PROGRAMS.len() {
             return Err(RauhaError::EbpfError {
-                message: "no LSM programs could be loaded".into(),
-                hint: "check kernel supports BPF LSM hooks".into(),
+                message: format!(
+                    "partial LSM attachment: attached {} of {} required programs",
+                    program_fds.len(),
+                    LSM_PROGRAMS.len()
+                ),
+                hint: "restart rauhad after fixing kernel BPF-LSM support".into(),
             });
         }
 

--- a/rauhad/src/backend/linux/events.rs
+++ b/rauhad/src/backend/linux/events.rs
@@ -1,12 +1,16 @@
 //! Enforcement event reader — drains the BPF ring buffer in a background task.
 //!
-//! Deny events from all 7 LSM hooks are streamed here, logged via tracing,
-//! and broadcast to any gRPC WatchEvents subscribers.
+//! Raw eBPF records are normalized at this edge into evidence-schema events,
+//! then broadcast to gRPC WatchEvents subscribers.
 
 use std::time::Duration;
 
 use aya::maps::{MapData, RingBuf};
 use rauha_ebpf_common::EnforcementEvent;
+use rauha_evidence::{
+    event_name, pipeline_shed_event, FalseEvent, FalseEventBuilder, FieldValue, ResourceAttrs,
+    Severity, BACKEND_LINUX_EBPF,
+};
 use tokio::sync::broadcast;
 
 const HOOK_NAMES: [&str; 7] = [
@@ -19,24 +23,13 @@ const HOOK_NAMES: [&str; 7] = [
     "socket_connect",
 ];
 
-/// A decoded enforcement event for userspace consumers.
-#[derive(Clone, Debug)]
-pub struct DecodedEvent {
-    pub timestamp_ns: u64,
-    pub pid: u32,
-    pub hook: String,
-    pub caller_zone: u32,
-    pub target_zone: u32,
-    pub context: u64,
-}
-
 /// Start the ring buffer reader as a background tokio task.
 ///
 /// Returns a broadcast Sender that gRPC handlers can subscribe to.
 pub fn spawn_event_reader(
     ring_buf: RingBuf<MapData>,
     cancel: tokio_util::sync::CancellationToken,
-) -> broadcast::Sender<DecodedEvent> {
+) -> broadcast::Sender<FalseEvent> {
     let (tx, _) = broadcast::channel(1024);
     let tx_clone = tx.clone();
 
@@ -50,7 +43,7 @@ pub fn spawn_event_reader(
 async fn run_event_loop(
     mut ring_buf: RingBuf<MapData>,
     cancel: tokio_util::sync::CancellationToken,
-    tx: broadcast::Sender<DecodedEvent>,
+    tx: broadcast::Sender<FalseEvent>,
 ) {
     let mut interval = tokio::time::interval(Duration::from_millis(100));
     tracing::info!("enforcement event reader started");
@@ -69,47 +62,126 @@ async fn run_event_loop(
     }
 }
 
-fn drain_events(ring_buf: &mut RingBuf<MapData>, tx: &broadcast::Sender<DecodedEvent>) {
+fn drain_events(ring_buf: &mut RingBuf<MapData>, tx: &broadcast::Sender<FalseEvent>) {
     while let Some(item) = ring_buf.next() {
         if item.len() < std::mem::size_of::<EnforcementEvent>() {
-            tracing::warn!(len = item.len(), "undersized enforcement event");
+            let event = FalseEventBuilder::new(event_name::PIPELINE_SHED)
+                .level(Severity::Warn)
+                .zone("zone-unknown", None)
+                .resource_attributes(ResourceAttrs::new(BACKEND_LINUX_EBPF))
+                .field(
+                    "reason",
+                    FieldValue::String("undersized_enforcement_event".into()),
+                )
+                .field("bytes", FieldValue::U64(item.len() as u64))
+                .build();
+            if let Ok(event) = event {
+                event.emit_tracing();
+                let _ = tx.send(event);
+            }
             continue;
         }
 
         let event: EnforcementEvent =
             unsafe { std::ptr::read_unaligned(item.as_ptr() as *const EnforcementEvent) };
 
-        let hook = HOOK_NAMES
-            .get(event.hook as usize)
-            .unwrap_or(&"unknown");
+        let evidence = normalize_enforcement_event(event);
+        evidence.emit_tracing();
 
-        if event.decision == rauha_ebpf_common::DECISION_ERROR {
-            tracing::error!(
-                hook = hook,
-                pid = event.pid,
-                "enforcement ERROR — hook failed open, kernel read may have failed. \
-                 Check if kernel struct offsets are correct for this kernel version."
-            );
-        } else {
-            tracing::warn!(
-                hook = hook,
-                pid = event.pid,
-                caller_zone = event.caller_zone,
-                target_zone = event.target_zone,
-                context = event.context,
-                timestamp_ns = event.timestamp_ns,
-                "enforcement DENY"
-            );
+        // Best-effort broadcast. If subscribers lag, WatchEvents converts that
+        // into a pipeline.shed evidence record; no drop is silent.
+        let _ = tx.send(evidence);
+    }
+}
+
+fn normalize_enforcement_event(event: EnforcementEvent) -> FalseEvent {
+    let hook = HOOK_NAMES
+        .get(event.hook as usize)
+        .copied()
+        .unwrap_or("unknown");
+    let event_name = event_name_for(event.hook, event.decision);
+    let level = if event.decision == rauha_ebpf_common::DECISION_ERROR {
+        Severity::Error
+    } else {
+        severity_for_event(event_name)
+    };
+    let zone_id = if event.caller_zone == 0 {
+        "zone-unassigned".to_string()
+    } else {
+        format!("zone-{}", event.caller_zone)
+    };
+    let resource = resource_for(event.hook, event.context);
+
+    FalseEventBuilder::new(event_name)
+        .level(level)
+        .zone(zone_id, None)
+        .actor(format!("pid:{}", event.pid), Vec::new())
+        .resource(resource)
+        .resource_attributes(ResourceAttrs::new(BACKEND_LINUX_EBPF))
+        .field("pid", FieldValue::U64(event.pid as u64))
+        .field("hook", FieldValue::String(hook.to_string()))
+        .field(
+            "decision",
+            FieldValue::String(decision_name(event.decision).into()),
+        )
+        .field("caller_zone", FieldValue::U64(event.caller_zone as u64))
+        .field("target_zone", FieldValue::U64(event.target_zone as u64))
+        .field("source_timestamp_ns", FieldValue::U64(event.timestamp_ns))
+        .field("context", FieldValue::U64(event.context))
+        .build()
+        .unwrap_or_else(|e| {
+            tracing::error!(%e, "failed to normalize enforcement event");
+            pipeline_shed_event("normalization_failed", BACKEND_LINUX_EBPF)
+        })
+}
+
+fn event_name_for(hook: u8, decision: u8) -> &'static str {
+    if decision == rauha_ebpf_common::DECISION_ERROR {
+        return event_name::PIPELINE_SHED;
+    }
+
+    match hook {
+        rauha_ebpf_common::HOOK_FILE_OPEN => event_name::ZONE_FILE_DENIED,
+        rauha_ebpf_common::HOOK_BPRM_CHECK => event_name::ZONE_EXEC_DENIED,
+        rauha_ebpf_common::HOOK_PTRACE_CHECK => event_name::ZONE_PTRACE_DENIED,
+        rauha_ebpf_common::HOOK_TASK_KILL => event_name::ZONE_SIGNAL_DENIED,
+        rauha_ebpf_common::HOOK_CGROUP_ATTACH => event_name::ZONE_ESCAPE_CGROUP_ATTACH,
+        rauha_ebpf_common::HOOK_SOCKET_CONNECT => event_name::ZONE_NET_DENIED,
+        rauha_ebpf_common::HOOK_CAPABLE => event_name::ZONE_MOUNT_DENIED,
+        _ => event_name::PIPELINE_SHED,
+    }
+}
+
+fn severity_for_event(event_name: &str) -> Severity {
+    match event_name {
+        event_name::ZONE_ESCAPE_CGROUP_ATTACH => Severity::Error,
+        event_name::ZONE_FILE_DENIED
+        | event_name::ZONE_EXEC_DENIED
+        | event_name::ZONE_PTRACE_DENIED
+        | event_name::ZONE_SIGNAL_DENIED
+        | event_name::ZONE_MOUNT_DENIED
+        | event_name::ZONE_IPC_DENIED
+        | event_name::ZONE_NET_DENIED => Severity::Warn,
+        _ => Severity::Info,
+    }
+}
+
+fn resource_for(hook: u8, context: u64) -> String {
+    match hook {
+        rauha_ebpf_common::HOOK_FILE_OPEN | rauha_ebpf_common::HOOK_BPRM_CHECK => {
+            format!("inode:{context}")
         }
+        rauha_ebpf_common::HOOK_CGROUP_ATTACH => format!("cgroup:{context}"),
+        rauha_ebpf_common::HOOK_SOCKET_CONNECT => format!("socket:{context}"),
+        _ => "kernel-object:unknown".into(),
+    }
+}
 
-        // Best-effort broadcast — if no subscribers, the send is a no-op.
-        let _ = tx.send(DecodedEvent {
-            timestamp_ns: event.timestamp_ns,
-            pid: event.pid,
-            hook: hook.to_string(),
-            caller_zone: event.caller_zone,
-            target_zone: event.target_zone,
-            context: event.context,
-        });
+fn decision_name(decision: u8) -> &'static str {
+    match decision {
+        rauha_ebpf_common::DECISION_ALLOW => "allow",
+        rauha_ebpf_common::DECISION_DENY => "deny",
+        rauha_ebpf_common::DECISION_ERROR => "error",
+        _ => "unknown",
     }
 }

--- a/rauhad/src/backend/linux/maps.rs
+++ b/rauhad/src/backend/linux/maps.rs
@@ -379,11 +379,17 @@ mod tests {
     }
 
     #[test]
-    fn policy_to_kernel_default_has_no_flags() {
+    fn policy_to_kernel_default_has_empty_capability_allow_list() {
         let k = policy_to_kernel(&ZonePolicy::default());
         assert_eq!(k.caps_mask, 0);
         assert_eq!(k.flags, 0);
         assert_eq!(k._pad, 0);
+    }
+
+    #[test]
+    fn policy_to_kernel_empty_capabilities_mean_allow_none() {
+        let k = policy_to_kernel(&default_policy_with_caps(vec![]));
+        assert_eq!(k.caps_mask, 0);
     }
 
     #[test]

--- a/rauhad/src/backend/linux/maps.rs
+++ b/rauhad/src/backend/linux/maps.rs
@@ -7,7 +7,7 @@ use aya::maps::HashMap as AyaHashMap;
 use aya::Bpf;
 
 use rauha_common::error::{RauhaError, Result};
-use rauha_common::zone::{ZonePolicy, ZoneType};
+use rauha_common::zone::{capabilities_to_mask, ZonePolicy, ZoneType};
 use rauha_ebpf_common::*;
 
 pub struct MapManager;
@@ -79,7 +79,7 @@ impl MapManager {
 
     /// Set the enforcement policy for a zone in the BPF map.
     pub fn set_zone_policy(bpf: &mut Bpf, zone_id: u32, policy: &ZonePolicy) -> Result<()> {
-        let kernel_policy = policy_to_kernel(policy);
+        let kernel_policy = policy_to_kernel(policy)?;
 
         let mut map: AyaHashMap<_, u32, ZonePolicyKernel> =
             AyaHashMap::try_from(bpf.map_mut("ZONE_POLICY").ok_or_else(|| {
@@ -344,8 +344,8 @@ pub fn collect_rootfs_inodes(rootfs_path: &std::path::Path, max_inodes: u32) -> 
 /// Convert userspace ZonePolicy to kernel-side ZonePolicyKernel.
 ///
 /// Maps capability names to a bitmask and policy settings to flag bits.
-fn policy_to_kernel(policy: &ZonePolicy) -> ZonePolicyKernel {
-    let caps_mask = caps_to_mask(&policy.capabilities.allowed);
+fn policy_to_kernel(policy: &ZonePolicy) -> Result<ZonePolicyKernel> {
+    let caps_mask = capabilities_to_mask(&policy.capabilities.allowed)?;
 
     let mut flags = 0u32;
     // Allow ptrace if SYS_PTRACE capability is granted.
@@ -360,11 +360,11 @@ fn policy_to_kernel(policy: &ZonePolicy) -> ZonePolicyKernel {
         flags |= POLICY_FLAG_ALLOW_HOST_NET;
     }
 
-    ZonePolicyKernel {
+    Ok(ZonePolicyKernel {
         caps_mask,
         flags,
         _pad: 0,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn policy_to_kernel_default_has_empty_capability_allow_list() {
-        let k = policy_to_kernel(&ZonePolicy::default());
+        let k = policy_to_kernel(&ZonePolicy::default()).unwrap();
         assert_eq!(k.caps_mask, 0);
         assert_eq!(k.flags, 0);
         assert_eq!(k._pad, 0);
@@ -388,25 +388,25 @@ mod tests {
 
     #[test]
     fn policy_to_kernel_empty_capabilities_mean_allow_none() {
-        let k = policy_to_kernel(&default_policy_with_caps(vec![]));
+        let k = policy_to_kernel(&default_policy_with_caps(vec![])).unwrap();
         assert_eq!(k.caps_mask, 0);
     }
 
     #[test]
     fn policy_to_kernel_sets_ptrace_flag_from_cap() {
-        let k = policy_to_kernel(&default_policy_with_caps(vec!["CAP_SYS_PTRACE"]));
+        let k = policy_to_kernel(&default_policy_with_caps(vec!["CAP_SYS_PTRACE"])).unwrap();
         assert_ne!(k.flags & POLICY_FLAG_ALLOW_PTRACE, 0);
     }
 
     #[test]
     fn policy_to_kernel_sets_ptrace_flag_from_short_form() {
-        let k = policy_to_kernel(&default_policy_with_caps(vec!["SYS_PTRACE"]));
+        let k = policy_to_kernel(&default_policy_with_caps(vec!["SYS_PTRACE"])).unwrap();
         assert_ne!(k.flags & POLICY_FLAG_ALLOW_PTRACE, 0);
     }
 
     #[test]
     fn policy_to_kernel_ptrace_flag_case_insensitive() {
-        let k = policy_to_kernel(&default_policy_with_caps(vec!["cap_sys_ptrace"]));
+        let k = policy_to_kernel(&default_policy_with_caps(vec!["cap_sys_ptrace"])).unwrap();
         assert_ne!(k.flags & POLICY_FLAG_ALLOW_PTRACE, 0);
     }
 
@@ -414,27 +414,27 @@ mod tests {
     fn policy_to_kernel_host_network_sets_flag() {
         let mut p = ZonePolicy::default();
         p.network.mode = NetworkMode::Host;
-        let k = policy_to_kernel(&p);
+        let k = policy_to_kernel(&p).unwrap();
         assert_ne!(k.flags & POLICY_FLAG_ALLOW_HOST_NET, 0);
     }
 
     #[test]
     fn policy_to_kernel_isolated_network_no_flag() {
         let p = ZonePolicy::default(); // default is Isolated
-        let k = policy_to_kernel(&p);
+        let k = policy_to_kernel(&p).unwrap();
         assert_eq!(k.flags & POLICY_FLAG_ALLOW_HOST_NET, 0);
     }
 
     #[test]
     fn policy_to_kernel_caps_mask_correct() {
-        let k = policy_to_kernel(&default_policy_with_caps(vec!["CAP_NET_ADMIN", "CAP_SYS_ADMIN"]));
+        let k = policy_to_kernel(&default_policy_with_caps(vec!["CAP_NET_ADMIN", "CAP_SYS_ADMIN"]))
+            .unwrap();
         // CAP_NET_ADMIN = bit 12, CAP_SYS_ADMIN = bit 21
         assert_eq!(k.caps_mask, (1 << 12) | (1 << 21));
     }
 
     #[test]
-    fn policy_to_kernel_unknown_cap_ignored() {
-        let k = policy_to_kernel(&default_policy_with_caps(vec!["CAP_NONEXISTENT"]));
-        assert_eq!(k.caps_mask, 0);
+    fn policy_to_kernel_unknown_cap_rejected() {
+        assert!(policy_to_kernel(&default_policy_with_caps(vec!["CAP_NONEXISTENT"])).is_err());
     }
 }

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -28,7 +28,6 @@ pub fn cleanup_network() {
 }
 
 use std::collections::HashMap;
-use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process::Command;
@@ -129,32 +128,15 @@ impl LinuxBackend {
         let cgroup = CgroupManager::new()?;
         let ip_allocator = IpAllocator::default_subnet();
 
-        // Try to load eBPF programs. If it fails, log a warning and continue
-        // in degraded mode (no kernel enforcement).
-        let (ebpf, event_reader_cancel, event_tx) = match Self::try_load_ebpf(root) {
-            Ok(mut mgr) => {
-                tracing::info!("eBPF programs loaded — kernel enforcement active");
+        let mut ebpf = Self::try_load_ebpf(root)?;
+        tracing::info!("eBPF programs loaded — kernel enforcement active");
 
-                // Start the enforcement event reader (ring buffer → tracing logs).
-                let (cancel, event_tx) = match mgr.take_event_ring_buf() {
-                    Ok(ring_buf) => {
-                        let token = tokio_util::sync::CancellationToken::new();
-                        let tx = events::spawn_event_reader(ring_buf, token.clone());
-                        (Some(token), Some(tx))
-                    }
-                    Err(e) => {
-                        tracing::warn!(%e, "enforcement event ring buffer not available");
-                        (None, None)
-                    }
-                };
-
-                (Some(mgr), cancel, event_tx)
-            }
-            Err(e) => {
-                tracing::warn!(%e, "eBPF programs not loaded — running without kernel enforcement");
-                (None, None, None)
-            }
-        };
+        let ring_buf = ebpf.take_event_ring_buf().map_err(|e| RauhaError::EbpfError {
+            message: format!("enforcement event ring buffer not available: {e}"),
+            hint: "check the ENFORCEMENT_EVENTS ring buffer map was created".into(),
+        })?;
+        let event_reader_cancel = tokio_util::sync::CancellationToken::new();
+        let event_tx = events::spawn_event_reader(ring_buf, event_reader_cancel.clone());
 
         // Ensure the network bridge exists with a gateway IP.
         if let Err(e) = network::ensure_bridge(ip_allocator.gateway(), ip_allocator.prefix_len()) {
@@ -172,15 +154,15 @@ impl LinuxBackend {
 
         Ok(Self {
             root: root.into(),
-            ebpf: Mutex::new(ebpf),
+            ebpf: Mutex::new(Some(ebpf)),
             cgroup,
             next_zone_id: AtomicU32::new(1), // 0 is reserved for "no zone".
             zone_id_map: Mutex::new(HashMap::new()),
             zone_name_map: Mutex::new(HashMap::new()),
             shim_connections: Mutex::new(HashMap::new()),
             registered_inodes: Mutex::new(HashMap::new()),
-            event_reader_cancel,
-            event_tx,
+            event_reader_cancel: Some(event_reader_cancel),
+            event_tx: Some(event_tx),
             ip_allocator: Mutex::new(ip_allocator),
         })
     }
@@ -441,10 +423,9 @@ impl IsolationBackend for LinuxBackend {
             self.cgroup.create_zone_cgroup(&zone.name)?
         };
 
-        // Re-apply resource limits.
-        if let Err(e) = self.cgroup.apply_resources(&zone.name, &policy.resources) {
-            tracing::warn!(%e, zone = zone.name, "failed to re-apply resource limits during recovery");
-        }
+        // Re-apply resource limits. Recovery must fail closed if hard limits
+        // cannot be restored.
+        self.cgroup.apply_resources(&zone.name, &policy.resources)?;
 
         // Re-register IP in allocator if zone has network state.
         if let Some(ref net_state) = zone.network_state {
@@ -462,17 +443,17 @@ impl IsolationBackend for LinuxBackend {
             }
         }
 
-        // Re-populate BPF maps.
-        if let Ok(ref mut ebpf_guard) = self.ebpf.lock() {
-            if let Some(ref mut ebpf) = **ebpf_guard {
-                let bpf = ebpf.bpf_mut();
-                if let Err(e) = MapManager::add_zone_member(bpf, cgroup_id, zone_id, zone_type) {
-                    tracing::warn!(%e, zone = zone.name, "failed to re-add zone to BPF map during recovery");
-                }
-                if let Err(e) = MapManager::set_zone_policy(bpf, zone_id, policy) {
-                    tracing::warn!(%e, zone = zone.name, "failed to re-set zone policy during recovery");
-                }
-            }
+        // Re-populate BPF maps. A recovered zone without BPF enforcement must
+        // not be treated as recovered.
+        {
+            let mut ebpf_guard = lock_or_abort(&self.ebpf);
+            let ebpf = ebpf_guard.as_mut().ok_or_else(|| RauhaError::EbpfError {
+                message: "eBPF manager not available during zone recovery".into(),
+                hint: "restart rauhad after restoring eBPF LSM support".into(),
+            })?;
+            let bpf = ebpf.bpf_mut();
+            MapManager::add_zone_member(bpf, cgroup_id, zone_id, zone_type)?;
+            MapManager::set_zone_policy(bpf, zone_id, policy)?;
         }
 
         tracing::info!(zone = zone.name, zone_id, cgroup_id, "zone recovered");
@@ -570,26 +551,59 @@ impl IsolationBackend for LinuxBackend {
             None
         };
 
-        // Step 3: Populate BPF maps.
-        if let Ok(ref mut ebpf_guard) = self.ebpf.lock() {
-            if let Some(ref mut ebpf) = **ebpf_guard {
-                let bpf = ebpf.bpf_mut();
+        let rollback_zone = |reason: &str| {
+            tracing::warn!(zone = config.name, reason, "rolling back failed zone creation");
+            if let Some(ref net_state) = net_state {
+                let mut alloc = lock_or_abort(&self.ip_allocator);
+                alloc.release(net_state.ip());
+            }
+            let _ = network::destroy_veth_pair(&config.name);
+            let _ = namespace::destroy_netns(&config.name);
+            let _ = self.cgroup.destroy_zone_cgroup(&config.name);
+            self.remove_zone_id(&zone_uuid);
+            lock_or_abort(&self.zone_name_map).remove(&config.name);
+        };
 
-                if let Err(e) =
-                    MapManager::add_zone_member(bpf, cgroup_id, zone_id, config.zone_type)
-                {
-                    tracing::warn!(%e, "failed to add zone to BPF membership map");
+        // Step 3: Populate BPF maps. Missing enforcement is fatal.
+        {
+            let mut ebpf_guard = lock_or_abort(&self.ebpf);
+            let ebpf = ebpf_guard.as_mut().ok_or_else(|| RauhaError::EbpfError {
+                message: "eBPF manager not available during zone creation".into(),
+                hint: "restart rauhad after restoring eBPF LSM support".into(),
+            });
+            let ebpf = match ebpf {
+                Ok(ebpf) => ebpf,
+                Err(e) => {
+                    rollback_zone("ebpf-unavailable");
+                    return Err(e);
                 }
+            };
 
-                if let Err(e) = MapManager::set_zone_policy(bpf, zone_id, &config.policy) {
-                    tracing::warn!(%e, "failed to set zone policy in BPF map");
-                }
+            let bpf = ebpf.bpf_mut();
+            if let Err(e) = MapManager::add_zone_member(bpf, cgroup_id, zone_id, config.zone_type) {
+                rollback_zone("bpf-membership");
+                return Err(e);
+            }
+
+            if let Err(e) = MapManager::set_zone_policy(bpf, zone_id, &config.policy) {
+                let _ = MapManager::remove_zone_member(bpf, cgroup_id);
+                rollback_zone("bpf-policy");
+                return Err(e);
             }
         }
 
         // Step 4: Apply cgroup resource limits.
         if let Err(e) = self.cgroup.apply_resources(&config.name, &config.policy.resources) {
-            tracing::warn!(%e, zone = config.name, "failed to apply resource limits");
+            if let Some(zone_id) = self.get_zone_id(&zone_uuid) {
+                let mut ebpf_guard = lock_or_abort(&self.ebpf);
+                if let Some(ref mut ebpf) = *ebpf_guard {
+                    let bpf = ebpf.bpf_mut();
+                    let _ = MapManager::remove_zone_member(bpf, cgroup_id);
+                    let _ = MapManager::remove_zone_policy(bpf, zone_id);
+                }
+            }
+            rollback_zone("resource-limits");
+            return Err(e);
         }
 
         tracing::info!(

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -456,8 +456,11 @@ impl IsolationBackend for LinuxBackend {
                 hint: "restart rauhad after restoring eBPF LSM support".into(),
             })?;
             let bpf = ebpf.bpf_mut();
-            MapManager::add_zone_member(bpf, cgroup_id, zone_id, zone_type)?;
+            // Policy before membership — a recovered cgroup may already hold
+            // running processes, so its ZONE_POLICY must exist before any of
+            // them can resolve as a zone member (else capable() fails closed).
             MapManager::set_zone_policy(bpf, zone_id, policy)?;
+            MapManager::add_zone_member(bpf, cgroup_id, zone_id, zone_type)?;
         }
 
         tracing::info!(zone = zone.name, zone_id, cgroup_id, "zone recovered");
@@ -592,14 +595,17 @@ impl IsolationBackend for LinuxBackend {
             };
 
             let bpf = ebpf.bpf_mut();
-            if let Err(e) = MapManager::add_zone_member(bpf, cgroup_id, zone_id, config.zone_type) {
-                rollback_zone("bpf-membership");
+            // Write the policy before membership: once a process resolves to a
+            // zone via ZONE_MEMBERSHIP, its ZONE_POLICY must already exist, or
+            // the fail-closed capable() hook would deny it in the gap.
+            if let Err(e) = MapManager::set_zone_policy(bpf, zone_id, &config.policy) {
+                rollback_zone("bpf-policy");
                 return Err(e);
             }
 
-            if let Err(e) = MapManager::set_zone_policy(bpf, zone_id, &config.policy) {
-                let _ = MapManager::remove_zone_member(bpf, cgroup_id);
-                rollback_zone("bpf-policy");
+            if let Err(e) = MapManager::add_zone_member(bpf, cgroup_id, zone_id, config.zone_type) {
+                let _ = MapManager::remove_zone_policy(bpf, zone_id);
+                rollback_zone("bpf-membership");
                 return Err(e);
             }
         }

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -119,7 +119,7 @@ pub struct LinuxBackend {
     /// Cancellation token for the enforcement event reader task.
     event_reader_cancel: Option<tokio_util::sync::CancellationToken>,
     /// Broadcast sender for enforcement events (gRPC WatchEvents subscribes here).
-    event_tx: Option<tokio::sync::broadcast::Sender<events::DecodedEvent>>,
+    event_tx: Option<tokio::sync::broadcast::Sender<rauha_evidence::FalseEvent>>,
     /// IP address allocator for zone networking.
     ip_allocator: Mutex<IpAllocator>,
 }
@@ -214,7 +214,7 @@ impl LinuxBackend {
     }
 
     /// Get a clone of the enforcement event broadcast sender, if available.
-    pub fn event_sender(&self) -> Option<tokio::sync::broadcast::Sender<events::DecodedEvent>> {
+    pub fn event_sender(&self) -> Option<tokio::sync::broadcast::Sender<rauha_evidence::FalseEvent>> {
         self.event_tx.clone()
     }
 

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -59,19 +59,14 @@ impl ShimConnection {
 
     /// Send a request to the shim and receive a response.
     fn send_request(&self, request: &ShimRequest) -> Result<ShimResponse> {
-        let mut stream = UnixStream::connect(&self.socket_path).map_err(|e| {
-            RauhaError::ShimError {
+        let mut stream =
+            UnixStream::connect(&self.socket_path).map_err(|e| RauhaError::ShimError {
                 zone: self.socket_path.display().to_string(),
                 message: format!("failed to connect to shim: {e}"),
-            }
-        })?;
+            })?;
 
-        stream
-            .set_read_timeout(Some(Duration::from_secs(30)))
-            .ok();
-        stream
-            .set_write_timeout(Some(Duration::from_secs(10)))
-            .ok();
+        stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+        stream.set_write_timeout(Some(Duration::from_secs(10))).ok();
 
         shim::encode_to(&mut stream, request).map_err(|e| RauhaError::ShimError {
             zone: self.socket_path.display().to_string(),
@@ -85,15 +80,11 @@ impl ShimConnection {
     }
 }
 
-/// Lock a mutex, aborting the process if poisoned.
-///
-/// Mutex poisoning means a thread panicked while holding the lock — the
-/// protected data is in an undefined state. Process abort (not just task
-/// panic) ensures the process actually terminates so systemd can restart it.
-fn lock_or_abort<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    mutex.lock().unwrap_or_else(|_| {
-        tracing::error!("mutex poisoned — daemon state corrupt, aborting for restart");
-        std::process::abort();
+/// Lock backend state, failing closed if the protected data may be corrupt.
+fn lock_backend<'a, T>(mutex: &'a Mutex<T>, name: &str) -> Result<MutexGuard<'a, T>> {
+    mutex.lock().map_err(|_| {
+        tracing::error!(state = name, "mutex poisoned — refusing backend operation");
+        RauhaError::BackendError(format!("linux backend state poisoned: {name}"))
     })
 }
 
@@ -131,10 +122,12 @@ impl LinuxBackend {
         let mut ebpf = Self::try_load_ebpf(root)?;
         tracing::info!("eBPF programs loaded — kernel enforcement active");
 
-        let ring_buf = ebpf.take_event_ring_buf().map_err(|e| RauhaError::EbpfError {
-            message: format!("enforcement event ring buffer not available: {e}"),
-            hint: "check the ENFORCEMENT_EVENTS ring buffer map was created".into(),
-        })?;
+        let ring_buf = ebpf
+            .take_event_ring_buf()
+            .map_err(|e| RauhaError::EbpfError {
+                message: format!("enforcement event ring buffer not available: {e}"),
+                hint: "check the ENFORCEMENT_EVENTS ring buffer map was created".into(),
+            })?;
         let event_reader_cancel = tokio_util::sync::CancellationToken::new();
         let event_tx = events::spawn_event_reader(ring_buf, event_reader_cancel.clone());
 
@@ -146,7 +139,14 @@ impl LinuxBackend {
         // Set up NAT masquerade for zone traffic.
         let subnet_cidr = {
             let s = ip_allocator.subnet();
-            format!("{}.{}.{}.{}/{}", s[0], s[1], s[2], s[3], ip_allocator.prefix_len())
+            format!(
+                "{}.{}.{}.{}/{}",
+                s[0],
+                s[1],
+                s[2],
+                s[3],
+                ip_allocator.prefix_len()
+            )
         };
         if let Err(e) = nftables::ensure_nat(&subnet_cidr) {
             tracing::warn!(%e, "failed to set up NAT — zones won't have internet access");
@@ -196,25 +196,29 @@ impl LinuxBackend {
     }
 
     /// Get a clone of the enforcement event broadcast sender, if available.
-    pub fn event_sender(&self) -> Option<tokio::sync::broadcast::Sender<rauha_evidence::FalseEvent>> {
+    pub fn event_sender(
+        &self,
+    ) -> Option<tokio::sync::broadcast::Sender<rauha_evidence::FalseEvent>> {
         self.event_tx.clone()
     }
 
     /// Allocate a new compact zone_id for BPF maps.
-    fn allocate_zone_id(&self, uuid: Uuid) -> u32 {
+    fn allocate_zone_id(&self, uuid: Uuid) -> Result<u32> {
         let id = self.next_zone_id.fetch_add(1, Ordering::Relaxed);
-        self.zone_id_map.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() }).insert(uuid, id);
-        id
+        lock_backend(&self.zone_id_map, "zone_id_map")?.insert(uuid, id);
+        Ok(id)
     }
 
     /// Look up the compact zone_id for a Uuid.
-    fn get_zone_id(&self, uuid: &Uuid) -> Option<u32> {
-        self.zone_id_map.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() }).get(uuid).copied()
+    fn get_zone_id(&self, uuid: &Uuid) -> Result<Option<u32>> {
+        Ok(lock_backend(&self.zone_id_map, "zone_id_map")?
+            .get(uuid)
+            .copied())
     }
 
     /// Remove zone_id mapping.
-    fn remove_zone_id(&self, uuid: &Uuid) -> Option<u32> {
-        self.zone_id_map.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() }).remove(uuid)
+    fn remove_zone_id(&self, uuid: &Uuid) -> Result<Option<u32>> {
+        Ok(lock_backend(&self.zone_id_map, "zone_id_map")?.remove(uuid))
     }
 
     /// Get the socket path for a zone's shim.
@@ -228,7 +232,7 @@ impl LinuxBackend {
 
         // Check if shim is already connected and responsive.
         {
-            let conns = self.shim_connections.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() });
+            let conns = lock_backend(&self.shim_connections, "shim_connections")?;
             if let Some(conn) = conns.get(zone_name) {
                 // Try a quick health check.
                 if conn
@@ -289,9 +293,7 @@ impl LinuxBackend {
 
         // Register connection.
         let conn = ShimConnection::new(socket_path);
-        self.shim_connections
-            .lock()
-            .unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() })
+        lock_backend(&self.shim_connections, "shim_connections")?
             .insert(zone_name.to_string(), conn);
 
         tracing::info!(zone = zone_name, "shim spawned");
@@ -300,7 +302,7 @@ impl LinuxBackend {
 
     /// Send a request to a zone's shim.
     fn shim_request(&self, zone_name: &str, request: &ShimRequest) -> Result<ShimResponse> {
-        let conns = self.shim_connections.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() });
+        let conns = lock_backend(&self.shim_connections, "shim_connections")?;
         let conn = conns.get(zone_name).ok_or_else(|| RauhaError::ShimError {
             zone: zone_name.into(),
             message: "no shim connection".into(),
@@ -330,8 +332,8 @@ impl LinuxBackend {
         zone_id: u32,
         net_policy: &NetworkPolicy,
     ) -> Result<()> {
-        let zone_names = self.zone_name_map.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() });
-        let zone_ids = self.zone_id_map.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() });
+        let zone_names = lock_backend(&self.zone_name_map, "zone_name_map")?;
+        let zone_ids = lock_backend(&self.zone_id_map, "zone_id_map")?;
 
         // Collect the set of peer zone_ids that should be allowed.
         let mut allowed_peer_ids: std::collections::HashSet<u32> = std::collections::HashSet::new();
@@ -406,15 +408,17 @@ fn find_shim_binary() -> Result<PathBuf> {
 }
 
 impl IsolationBackend for LinuxBackend {
-    fn recover_zone(&self, zone: &ZoneHandle, zone_type: ZoneType, policy: &ZonePolicy) -> Result<()> {
+    fn recover_zone(
+        &self,
+        zone: &ZoneHandle,
+        zone_type: ZoneType,
+        policy: &ZonePolicy,
+    ) -> Result<()> {
         tracing::info!(zone = zone.name, "recovering zone state from metadata");
 
         // Allocate a compact zone_id (these are ephemeral, not persisted).
-        let zone_id = self.allocate_zone_id(zone.id);
-        self.zone_name_map
-            .lock()
-            .unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() })
-            .insert(zone.name.clone(), zone.id);
+        let zone_id = self.allocate_zone_id(zone.id)?;
+        lock_backend(&self.zone_name_map, "zone_name_map")?.insert(zone.name.clone(), zone.id);
 
         // Re-create cgroup if missing (idempotent).
         let cgroup_id = if self.cgroup.zone_cgroup_exists(&zone.name) {
@@ -429,7 +433,7 @@ impl IsolationBackend for LinuxBackend {
 
         // Re-register IP in allocator if zone has network state.
         if let Some(ref net_state) = zone.network_state {
-            self.ip_allocator.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() }).mark_allocated(net_state.ip());
+            lock_backend(&self.ip_allocator, "ip_allocator")?.mark_allocated(net_state.ip());
         }
 
         // Re-create netns if missing (idempotent).
@@ -446,7 +450,7 @@ impl IsolationBackend for LinuxBackend {
         // Re-populate BPF maps. A recovered zone without BPF enforcement must
         // not be treated as recovered.
         {
-            let mut ebpf_guard = lock_or_abort(&self.ebpf);
+            let mut ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
             let ebpf = ebpf_guard.as_mut().ok_or_else(|| RauhaError::EbpfError {
                 message: "eBPF manager not available during zone recovery".into(),
                 hint: "restart rauhad after restoring eBPF LSM support".into(),
@@ -505,19 +509,16 @@ impl IsolationBackend for LinuxBackend {
         tracing::info!(zone = config.name, backend = "linux-ebpf", "creating zone");
 
         let zone_uuid = Uuid::new_v4();
-        let zone_id = self.allocate_zone_id(zone_uuid);
+        let zone_id = self.allocate_zone_id(zone_uuid)?;
 
         // Track zone name → uuid mapping.
-        self.zone_name_map
-            .lock()
-            .unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() })
-            .insert(config.name.clone(), zone_uuid);
+        lock_backend(&self.zone_name_map, "zone_name_map")?.insert(config.name.clone(), zone_uuid);
 
         // Step 1: Create cgroup.
         let cgroup_id = match self.cgroup.create_zone_cgroup(&config.name) {
             Ok(id) => id,
             Err(e) => {
-                self.remove_zone_id(&zone_uuid);
+                let _ = self.remove_zone_id(&zone_uuid);
                 return Err(e);
             }
         };
@@ -526,7 +527,7 @@ impl IsolationBackend for LinuxBackend {
         let net_state = if config.policy.network.mode != NetworkMode::Host {
             // Allocate an IP for this zone.
             let ip_state = {
-                let mut alloc = self.ip_allocator.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() });
+                let mut alloc = lock_backend(&self.ip_allocator, "ip_allocator")?;
                 let ip = alloc.allocate()?;
                 ZoneNetworkState {
                     ip: ip.octets(),
@@ -552,21 +553,32 @@ impl IsolationBackend for LinuxBackend {
         };
 
         let rollback_zone = |reason: &str| {
-            tracing::warn!(zone = config.name, reason, "rolling back failed zone creation");
+            tracing::warn!(
+                zone = config.name,
+                reason,
+                "rolling back failed zone creation"
+            );
             if let Some(ref net_state) = net_state {
-                let mut alloc = lock_or_abort(&self.ip_allocator);
-                alloc.release(net_state.ip());
+                match lock_backend(&self.ip_allocator, "ip_allocator") {
+                    Ok(mut alloc) => alloc.release(net_state.ip()),
+                    Err(e) => tracing::error!(%e, "failed to release zone IP during rollback"),
+                }
             }
             let _ = network::destroy_veth_pair(&config.name);
             let _ = namespace::destroy_netns(&config.name);
             let _ = self.cgroup.destroy_zone_cgroup(&config.name);
-            self.remove_zone_id(&zone_uuid);
-            lock_or_abort(&self.zone_name_map).remove(&config.name);
+            let _ = self.remove_zone_id(&zone_uuid);
+            match lock_backend(&self.zone_name_map, "zone_name_map") {
+                Ok(mut names) => {
+                    names.remove(&config.name);
+                }
+                Err(e) => tracing::error!(%e, "failed to remove zone name during rollback"),
+            }
         };
 
         // Step 3: Populate BPF maps. Missing enforcement is fatal.
         {
-            let mut ebpf_guard = lock_or_abort(&self.ebpf);
+            let mut ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
             let ebpf = ebpf_guard.as_mut().ok_or_else(|| RauhaError::EbpfError {
                 message: "eBPF manager not available during zone creation".into(),
                 hint: "restart rauhad after restoring eBPF LSM support".into(),
@@ -593,9 +605,12 @@ impl IsolationBackend for LinuxBackend {
         }
 
         // Step 4: Apply cgroup resource limits.
-        if let Err(e) = self.cgroup.apply_resources(&config.name, &config.policy.resources) {
-            if let Some(zone_id) = self.get_zone_id(&zone_uuid) {
-                let mut ebpf_guard = lock_or_abort(&self.ebpf);
+        if let Err(e) = self
+            .cgroup
+            .apply_resources(&config.name, &config.policy.resources)
+        {
+            if let Some(zone_id) = self.get_zone_id(&zone_uuid)? {
+                let mut ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
                 if let Some(ref mut ebpf) = *ebpf_guard {
                     let bpf = ebpf.bpf_mut();
                     let _ = MapManager::remove_zone_member(bpf, cgroup_id);
@@ -606,12 +621,7 @@ impl IsolationBackend for LinuxBackend {
             return Err(e);
         }
 
-        tracing::info!(
-            zone = config.name,
-            zone_id,
-            cgroup_id,
-            "zone created"
-        );
+        tracing::info!(zone = config.name, zone_id, cgroup_id, "zone created");
 
         Ok(ZoneHandle {
             id: zone_uuid,
@@ -626,24 +636,31 @@ impl IsolationBackend for LinuxBackend {
 
         // Shut down shim if running.
         {
-            let mut conns = self.shim_connections.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() });
+            let mut conns = lock_backend(&self.shim_connections, "shim_connections")?;
             if let Some(conn) = conns.remove(&zone.name) {
                 let _ = conn.send_request(&ShimRequest::Shutdown);
             }
         }
 
         // Remove from BPF maps first.
-        let zone_id = self.remove_zone_id(&zone.id);
+        let zone_id = self.remove_zone_id(&zone.id)?;
         // Remove stored inodes from BPF map (uses stored list, no re-walk).
         let stored_inodes = self
             .registered_inodes
             .lock()
-            .unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() })
+            .map_err(|_| {
+                tracing::error!(
+                    state = "registered_inodes",
+                    "mutex poisoned — refusing backend operation"
+                );
+                RauhaError::BackendError("linux backend state poisoned: registered_inodes".into())
+            })?
             .remove(&zone.name)
             .unwrap_or_default();
 
-        if let (Some(zone_id), Ok(ref mut ebpf_guard)) = (zone_id, self.ebpf.lock()) {
-            if let Some(ref mut ebpf) = **ebpf_guard {
+        if let Some(zone_id) = zone_id {
+            let mut ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
+            if let Some(ref mut ebpf) = *ebpf_guard {
                 let bpf = ebpf.bpf_mut();
 
                 if !stored_inodes.is_empty() {
@@ -659,7 +676,7 @@ impl IsolationBackend for LinuxBackend {
 
         // Release IP back to allocator.
         if let Some(ref net_state) = zone.network_state {
-            let mut alloc = self.ip_allocator.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() });
+            let mut alloc = lock_backend(&self.ip_allocator, "ip_allocator")?;
             alloc.release(net_state.ip());
         }
 
@@ -675,7 +692,7 @@ impl IsolationBackend for LinuxBackend {
         // Destroy cgroup last (must be empty).
         self.cgroup.destroy_zone_cgroup(&zone.name)?;
 
-        self.zone_name_map.lock().unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() }).remove(&zone.name);
+        lock_backend(&self.zone_name_map, "zone_name_map")?.remove(&zone.name);
 
         // Clean up shim socket.
         let socket_path = Self::shim_socket_path(&zone.name);
@@ -689,15 +706,16 @@ impl IsolationBackend for LinuxBackend {
         tracing::info!(zone = zone.name, "enforcing policy");
 
         // Update BPF policy map.
-        if let Some(zone_id) = self.get_zone_id(&zone.id) {
-            if let Ok(ref mut ebpf_guard) = self.ebpf.lock() {
-                if let Some(ref mut ebpf) = **ebpf_guard {
-                    MapManager::set_zone_policy(ebpf.bpf_mut(), zone_id, policy)?;
+        if let Some(zone_id) = self.get_zone_id(&zone.id)? {
+            let mut ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
+            let ebpf = ebpf_guard.as_mut().ok_or_else(|| RauhaError::EbpfError {
+                message: "eBPF manager not available during policy enforcement".into(),
+                hint: "restart rauhad after restoring eBPF LSM support".into(),
+            })?;
+            MapManager::set_zone_policy(ebpf.bpf_mut(), zone_id, policy)?;
 
-                    // Wire up ZONE_ALLOWED_COMMS BPF map for defense-in-depth.
-                    self.sync_bpf_allowed_comms(ebpf.bpf_mut(), zone_id, &policy.network)?;
-                }
-            }
+            // Wire up ZONE_ALLOWED_COMMS BPF map for defense-in-depth.
+            self.sync_bpf_allowed_comms(ebpf.bpf_mut(), zone_id, &policy.network)?;
         }
 
         // Apply nftables forward rules for this zone.
@@ -713,15 +731,16 @@ impl IsolationBackend for LinuxBackend {
         tracing::info!(zone = zone.name, "hot-reloading policy");
 
         // BPF HashMap insert is atomic — kernel sees old or new, never partial.
-        if let Some(zone_id) = self.get_zone_id(&zone.id) {
-            if let Ok(ref mut ebpf_guard) = self.ebpf.lock() {
-                if let Some(ref mut ebpf) = **ebpf_guard {
-                    MapManager::hot_reload_policy(ebpf.bpf_mut(), zone_id, policy)?;
+        if let Some(zone_id) = self.get_zone_id(&zone.id)? {
+            let mut ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
+            let ebpf = ebpf_guard.as_mut().ok_or_else(|| RauhaError::EbpfError {
+                message: "eBPF manager not available during policy hot reload".into(),
+                hint: "restart rauhad after restoring eBPF LSM support".into(),
+            })?;
+            MapManager::hot_reload_policy(ebpf.bpf_mut(), zone_id, policy)?;
 
-                    // Re-sync allowed comms on hot reload.
-                    self.sync_bpf_allowed_comms(ebpf.bpf_mut(), zone_id, &policy.network)?;
-                }
-            }
+            // Re-sync allowed comms on hot reload.
+            self.sync_bpf_allowed_comms(ebpf.bpf_mut(), zone_id, &policy.network)?;
         }
 
         // Re-apply nftables rules.
@@ -758,11 +777,7 @@ impl IsolationBackend for LinuxBackend {
             let snapshotter = rauha_oci::snapshotter::OverlayfsSnapshotter::new(
                 &PathBuf::from(&self.root).join("zones").join(&zone.name),
             );
-            snapshotter.mount_overlay(
-                &container_id.to_string(),
-                overlay_layers,
-                &container_dir,
-            )?
+            snapshotter.mount_overlay(&container_id.to_string(), overlay_layers, &container_dir)?
         } else if let Some(ref base_rootfs) = spec.rootfs_path {
             let rootfs_dir = container_dir.join("rootfs");
             copy_dir_recursive(base_rootfs, &rootfs_dir)?;
@@ -826,7 +841,7 @@ impl IsolationBackend for LinuxBackend {
         // Register rootfs inodes in BPF map for file isolation.
         // Phase 1: Collect inodes from filesystem (no lock, may be slow for large rootfs).
         // Phase 2: Insert into BPF map (short lock hold).
-        if let Some(zone_id) = self.get_zone_id(&zone.id) {
+        if let Some(zone_id) = self.get_zone_id(&zone.id)? {
             let is_overlay = rootfs_dir.ends_with("merged");
             tracing::debug!(
                 zone = zone.name,
@@ -835,39 +850,37 @@ impl IsolationBackend for LinuxBackend {
                 "collecting rootfs inodes for BPF file isolation"
             );
 
-            let inodes = maps::collect_rootfs_inodes(
-                &rootfs_dir,
-                rauha_ebpf_common::MAX_INODES,
-            );
+            let inodes = maps::collect_rootfs_inodes(&rootfs_dir, rauha_ebpf_common::MAX_INODES);
 
             if !inodes.is_empty() {
-                if let Ok(ref mut ebpf_guard) = self.ebpf.lock() {
-                    if let Some(ref mut ebpf) = **ebpf_guard {
-                        match MapManager::insert_inodes(ebpf.bpf_mut(), &inodes, zone_id) {
-                            Ok(inserted) => {
-                                // Store only successfully inserted inodes for cleanup.
-                                // This prevents removing entries that were never in the map.
-                                lock_or_abort(&self.registered_inodes)
-                                    .entry(zone.name.clone())
-                                    .or_default()
-                                    .extend_from_slice(&inserted);
-                                tracing::info!(
-                                    zone = zone.name,
-                                    container = %container_id,
-                                    count = inserted.len(),
-                                    collected = inodes.len(),
-                                    "registered container rootfs inodes in BPF map"
-                                );
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    %e,
-                                    zone = zone.name,
-                                    container = %container_id,
-                                    "failed to register rootfs inodes — file isolation incomplete"
-                                );
-                            }
-                        }
+                let mut ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
+                let ebpf = ebpf_guard.as_mut().ok_or_else(|| RauhaError::EbpfError {
+                    message: "eBPF manager not available during rootfs inode registration".into(),
+                    hint: "restart rauhad after restoring eBPF LSM support".into(),
+                })?;
+                match MapManager::insert_inodes(ebpf.bpf_mut(), &inodes, zone_id) {
+                    Ok(inserted) => {
+                        // Store only successfully inserted inodes for cleanup.
+                        // This prevents removing entries that were never in the map.
+                        lock_backend(&self.registered_inodes, "registered_inodes")?
+                            .entry(zone.name.clone())
+                            .or_default()
+                            .extend_from_slice(&inserted);
+                        tracing::info!(
+                            zone = zone.name,
+                            container = %container_id,
+                            count = inserted.len(),
+                            collected = inodes.len(),
+                            "registered container rootfs inodes in BPF map"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            %e,
+                            zone = zone.name,
+                            container = %container_id,
+                            "failed to register rootfs inodes — file isolation incomplete"
+                        );
                     }
                 }
             }
@@ -910,10 +923,8 @@ impl IsolationBackend for LinuxBackend {
         tracing::info!(container = %container.id, "starting container");
 
         // Look up zone name for this container.
-        let zone_name = self
-            .zone_name_map
-            .lock()
-            .unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() })
+        let zone_names = lock_backend(&self.zone_name_map, "zone_name_map")?;
+        let zone_name = zone_names
             .iter()
             .find(|(_, uuid)| **uuid == container.zone_id)
             .map(|(name, _)| name.clone())
@@ -945,10 +956,8 @@ impl IsolationBackend for LinuxBackend {
     fn stop_container(&self, container: &ContainerHandle) -> Result<()> {
         tracing::info!(container = %container.id, "stopping container");
 
-        let zone_name = self
-            .zone_name_map
-            .lock()
-            .unwrap_or_else(|_| { tracing::error!("mutex poisoned"); std::process::abort() })
+        let zone_names = lock_backend(&self.zone_name_map, "zone_name_map")?;
+        let zone_name = zone_names
             .iter()
             .find(|(_, uuid)| **uuid == container.zone_id)
             .map(|(name, _)| name.clone())
@@ -1004,8 +1013,9 @@ impl IsolationBackend for LinuxBackend {
         });
 
         // Check 2: eBPF programs loaded.
-        let ebpf_ok = if let Ok(ref ebpf_guard) = self.ebpf.lock() {
-            if let Some(ref ebpf) = **ebpf_guard {
+        let ebpf_ok = {
+            let ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
+            if let Some(ref ebpf) = *ebpf_guard {
                 match ebpf.health_check() {
                     Ok(statuses) => {
                         let all_ok = statuses.iter().all(|s| s.loaded && s.attached);
@@ -1043,12 +1053,10 @@ impl IsolationBackend for LinuxBackend {
                 });
                 false
             }
-        } else {
-            false
         };
 
         // Check 3: zone membership in BPF map.
-        let membership_ok = self.get_zone_id(&zone.id).is_some();
+        let membership_ok = self.get_zone_id(&zone.id)?.is_some();
         checks.push(IsolationCheck {
             name: "bpf_membership".into(),
             passed: membership_ok,
@@ -1072,29 +1080,28 @@ impl IsolationBackend for LinuxBackend {
         });
 
         // Check 5: enforcement counters — detect silent enforcement failure.
-        if let Ok(ref ebpf_guard) = self.ebpf.lock() {
-            if let Some(ref ebpf) = **ebpf_guard {
-                if let Ok(counters) = ebpf.read_enforcement_counters() {
-                    for (name, c) in &counters {
-                        if c.error > 0 && c.deny == 0 {
-                            checks.push(IsolationCheck {
-                                name: format!("enforcement:{name}"),
-                                passed: false,
-                                detail: format!(
-                                    "hook has {} errors and 0 denials — enforcement may be silently failing",
-                                    c.error
-                                ),
-                            });
-                        } else if c.allow > 0 || c.deny > 0 {
-                            checks.push(IsolationCheck {
-                                name: format!("enforcement:{name}"),
-                                passed: true,
-                                detail: format!(
-                                    "allow={}, deny={}, error={}",
-                                    c.allow, c.deny, c.error
-                                ),
-                            });
-                        }
+        let ebpf_guard = lock_backend(&self.ebpf, "ebpf")?;
+        if let Some(ref ebpf) = *ebpf_guard {
+            if let Ok(counters) = ebpf.read_enforcement_counters() {
+                for (name, c) in &counters {
+                    if c.error > 0 && c.deny == 0 {
+                        checks.push(IsolationCheck {
+                            name: format!("enforcement:{name}"),
+                            passed: false,
+                            detail: format!(
+                                "hook has {} errors and 0 denials — enforcement may be silently failing",
+                                c.error
+                            ),
+                        });
+                    } else if c.allow > 0 || c.deny > 0 {
+                        checks.push(IsolationCheck {
+                            name: format!("enforcement:{name}"),
+                            passed: true,
+                            detail: format!(
+                                "allow={}, deny={}, error={}",
+                                c.allow, c.deny, c.error
+                            ),
+                        });
                     }
                 }
             }
@@ -1175,4 +1182,25 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lock_backend;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn poisoned_backend_lock_returns_error() {
+        let mutex = Arc::new(Mutex::new(()));
+        let poisoned = Arc::clone(&mutex);
+
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoned.lock().expect("test lock should be available");
+            panic!("poison test mutex");
+        })
+        .join();
+
+        let err = lock_backend(&mutex, "test_state").expect_err("poisoned lock must fail closed");
+        assert!(err.to_string().contains("test_state"));
+    }
 }

--- a/rauhad/src/backend/mod.rs
+++ b/rauhad/src/backend/mod.rs
@@ -9,7 +9,7 @@ pub mod macos;
 
 /// Enforcement event broadcast sender type (Linux only).
 #[cfg(target_os = "linux")]
-pub type EventSender = tokio::sync::broadcast::Sender<linux::events::DecodedEvent>;
+pub type EventSender = tokio::sync::broadcast::Sender<rauha_evidence::FalseEvent>;
 
 /// Create the platform-appropriate isolation backend.
 #[cfg(target_os = "linux")]

--- a/rauhad/src/server.rs
+++ b/rauhad/src/server.rs
@@ -4,6 +4,10 @@ use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 
 use rauha_common::error::RauhaError;
+#[cfg(target_os = "linux")]
+use rauha_evidence::{
+    event_name, FalseEventBuilder, FieldValue, ResourceAttrs, Severity, BACKEND_LINUX_EBPF,
+};
 
 use crate::zone::registry::ZoneRegistry;
 
@@ -61,7 +65,7 @@ pub struct ZoneServiceImpl {
     root: String,
     /// Enforcement event broadcast sender (Linux only, None on macOS).
     #[cfg(target_os = "linux")]
-    event_tx: Option<tokio::sync::broadcast::Sender<crate::backend::linux::events::DecodedEvent>>,
+    event_tx: Option<tokio::sync::broadcast::Sender<rauha_evidence::FalseEvent>>,
 }
 
 impl ZoneServiceImpl {
@@ -69,7 +73,7 @@ impl ZoneServiceImpl {
         registry: Arc<ZoneRegistry>,
         root: String,
         #[cfg(target_os = "linux")]
-        event_tx: Option<tokio::sync::broadcast::Sender<crate::backend::linux::events::DecodedEvent>>,
+        event_tx: Option<tokio::sync::broadcast::Sender<rauha_evidence::FalseEvent>>,
     ) -> Self {
         Self {
             registry,
@@ -300,8 +304,15 @@ impl ZoneService for ZoneServiceImpl {
         &self,
         request: Request<pb::zone::WatchEventsRequest>,
     ) -> Result<Response<Self::WatchEventsStream>, Status> {
+        #[cfg(target_os = "linux")]
         let zone_filter = request.into_inner().zone_name;
+        #[cfg(not(target_os = "linux"))]
+        let _ = request.into_inner();
+
+        #[cfg(target_os = "linux")]
         let (tx, rx) = mpsc::channel(128);
+        #[cfg(not(target_os = "linux"))]
+        let (_tx, rx) = mpsc::channel(128);
 
         #[cfg(target_os = "linux")]
         if let Some(event_tx) = &self.event_tx {
@@ -312,20 +323,28 @@ impl ZoneService for ZoneServiceImpl {
                         Ok(event) => {
                             // Filter by zone if requested.
                             if !zone_filter.is_empty() {
-                                // Zone filter matches on caller_zone as string.
-                                // For now, filter on zone_id as string (callers can
-                                // filter by name once we add zone name resolution).
+                                let matches_zone = event.zone.name.as_deref()
+                                    == Some(zone_filter.as_str())
+                                    || event.zone.id == zone_filter;
+                                if !matches_zone {
+                                    continue;
+                                }
                             }
 
                             let grpc_event = pb::zone::ZoneEvent {
-                                zone_name: format!("zone-{}", event.caller_zone),
-                                event_type: "enforcement_deny".to_string(),
-                                message: format!(
-                                    "DENY {} pid={} caller_zone={} target_zone={} context={}",
-                                    event.hook, event.pid, event.caller_zone,
-                                    event.target_zone, event.context
-                                ),
-                                timestamp: event.timestamp_ns.to_string(),
+                                zone_name: event
+                                    .zone
+                                    .name
+                                    .clone()
+                                    .unwrap_or_else(|| event.zone.id.clone()),
+                                event_type: event.event.clone(),
+                                message: event.machine_json().unwrap_or_else(|e| {
+                                    format!(
+                                        r#"{{"event":"{}","serialization_error":"{}"}}"#,
+                                        event.event, e
+                                    )
+                                }),
+                                timestamp: event.ts.clone(),
                             };
 
                             if tx.send(Ok(grpc_event)).await.is_err() {
@@ -334,7 +353,40 @@ impl ZoneService for ZoneServiceImpl {
                             }
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            tracing::warn!(n, "event subscriber lagged, dropped events");
+                            let shed = FalseEventBuilder::new(event_name::PIPELINE_SHED)
+                                .level(Severity::Warn)
+                                .zone(
+                                    if zone_filter.is_empty() {
+                                        "zone-unknown".to_string()
+                                    } else {
+                                        zone_filter.clone()
+                                    },
+                                    None,
+                                )
+                                .resource_attributes(ResourceAttrs::new(BACKEND_LINUX_EBPF))
+                                .field("shed_events", FieldValue::U64(n))
+                                .field(
+                                    "reason",
+                                    FieldValue::String("watch_subscriber_lagged".into()),
+                                )
+                                .build();
+                            if let Ok(shed) = shed {
+                                shed.emit_tracing();
+                                let grpc_event = pb::zone::ZoneEvent {
+                                    zone_name: shed.zone.id.clone(),
+                                    event_type: shed.event.clone(),
+                                    message: shed.machine_json().unwrap_or_else(|e| {
+                                        format!(
+                                            r#"{{"event":"{}","serialization_error":"{}"}}"#,
+                                            shed.event, e
+                                        )
+                                    }),
+                                    timestamp: shed.ts.clone(),
+                                };
+                                if tx.send(Ok(grpc_event)).await.is_err() {
+                                    break;
+                                }
+                            }
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     }

--- a/rauhad/src/zone/policy.rs
+++ b/rauhad/src/zone/policy.rs
@@ -186,7 +186,11 @@ deny = ["mount", "umount2"]
     }
 
     #[test]
-    fn missing_capabilities_section_is_empty_allow_list() {
+    fn missing_capabilities_section_means_unrestricted() {
+        // An omitted [capabilities] section parses to an empty allow list, which
+        // compiles to caps_mask == 0. The capable() LSM hook treats caps_mask == 0
+        // as "no capability restriction" (allow), NOT "deny every capability" —
+        // see rauha-ebpf/src/capable_guard.rs. Restriction is opt-in.
         let toml = r#"
 [zone]
 name = "minimal"

--- a/rauhad/src/zone/policy.rs
+++ b/rauhad/src/zone/policy.rs
@@ -196,4 +196,59 @@ type = "non-global"
         let (_zone_type, policy) = parse_policy(toml, "/var/lib/rauha").unwrap();
         assert!(policy.capabilities.allowed.is_empty());
     }
+
+    #[test]
+    fn unknown_top_level_policy_key_is_rejected() {
+        let toml = r#"
+[zone]
+name = "strict"
+type = "non-global"
+
+[surprise]
+enabled = true
+"#;
+
+        assert!(parse_policy(toml, "/var/lib/rauha").is_err());
+    }
+
+    #[test]
+    fn unknown_nested_policy_key_is_rejected() {
+        let toml = r#"
+[zone]
+name = "strict"
+type = "non-global"
+extra = "nope"
+"#;
+
+        assert!(parse_policy(toml, "/var/lib/rauha").is_err());
+    }
+
+    #[test]
+    fn unknown_capability_is_rejected() {
+        let toml = r#"
+[zone]
+name = "strict"
+type = "non-global"
+
+[capabilities]
+allowed = ["CAP_NET_BIND_SERVICE", "CAP_NOT_REAL"]
+"#;
+
+        assert!(parse_policy(toml, "/var/lib/rauha").is_err());
+    }
+
+    #[test]
+    fn capability_short_form_is_accepted() {
+        let toml = r#"
+[zone]
+name = "strict"
+type = "non-global"
+
+[capabilities]
+allowed = ["net_bind_service"]
+"#;
+
+        let (_zone_type, policy) = parse_policy(toml, "/var/lib/rauha").unwrap();
+        assert_eq!(policy.capabilities.allowed, vec!["net_bind_service"]);
+    }
 }

--- a/rauhad/src/zone/policy.rs
+++ b/rauhad/src/zone/policy.rs
@@ -184,4 +184,16 @@ deny = ["mount", "umount2"]
         assert_eq!(policy.network.allowed_zones, vec!["frontend"]);
         assert_eq!(policy.syscalls.deny, vec!["mount", "umount2"]);
     }
+
+    #[test]
+    fn missing_capabilities_section_is_empty_allow_list() {
+        let toml = r#"
+[zone]
+name = "minimal"
+type = "non-global"
+"#;
+
+        let (_zone_type, policy) = parse_policy(toml, "/var/lib/rauha").unwrap();
+        assert!(policy.capabilities.allowed.is_empty());
+    }
 }

--- a/tests/integration/test-cgroup-lock.sh
+++ b/tests/integration/test-cgroup-lock.sh
@@ -14,9 +14,16 @@ ZONE_A="test-cglock-a-$$"
 ZONE_B="test-cglock-b-$$"
 IMAGE="${TEST_IMAGE:-alpine:latest}"
 FIFO="/tmp/rauha-test-cglock-$$"
+RESULT_FILE="/tmp/rauha-test-cglock-result-$$"
+ERR_FILE="/tmp/rauha-test-cglock-error-$$"
+HELPER_PID=""
 
 cleanup() {
-    rm -f "$FIFO"
+    if [ -n "${HELPER_PID:-}" ]; then
+        kill "$HELPER_PID" 2>/dev/null || true
+        wait "$HELPER_PID" 2>/dev/null || true
+    fi
+    rm -f "$FIFO" "$RESULT_FILE" "$ERR_FILE"
     $RAUHA zone delete --name "$ZONE_A" --force 2>/dev/null || true
     $RAUHA zone delete --name "$ZONE_B" --force 2>/dev/null || true
 }
@@ -74,9 +81,17 @@ mkfifo "$FIFO"
     # Wait until we've been enrolled in zone A.
     cat "$FIFO" > /dev/null
 
-    # Try to move ourselves to zone B's cgroup.
-    # Use /bin/sh -c with $$ to get the shell's own PID (not the subshell's).
-    /bin/sh -c "echo \$\$ > '${CGROUP_B}/cgroup.procs' 2>/dev/null; echo \$?" 2>/dev/null
+    # Try to move this helper process to zone B's cgroup. Use BASHPID so the
+    # helper writes its own PID, not the parent script's PID.
+    set +e
+    echo "$BASHPID" > "${CGROUP_B}/cgroup.procs" 2>"$ERR_FILE"
+    rc=$?
+    printf '%s\n' "$rc" > "$RESULT_FILE"
+
+    # Stay alive long enough for the parent to observe cgroup membership if the
+    # write unexpectedly succeeds. Without this, a successful move can be hidden
+    # by process exit before cgroup.procs is checked.
+    sleep 10
 ) &
 HELPER_PID=$!
 
@@ -95,10 +110,24 @@ fi
 # Signal helper to proceed with the cross-zone move attempt.
 echo "go" > "$FIFO"
 
-# Capture the helper's output (the exit code of the echo command).
-RESULT=""
-if read -t 5 RESULT < <(wait "$HELPER_PID" 2>/dev/null; echo "$?"); then
-    : # got result
+# Capture the helper's cgroup.procs write result.
+for _ in $(seq 1 50); do
+    if [ -s "$RESULT_FILE" ]; then
+        break
+    fi
+    sleep 0.1
+done
+
+if [ ! -s "$RESULT_FILE" ]; then
+    echo "  FAIL: helper did not report cross-zone cgroup move result"
+    exit 1
+fi
+
+RESULT=$(cat "$RESULT_FILE")
+if [ "$RESULT" -eq 0 ]; then
+    echo "  FAIL: cross-zone cgroup move write succeeded"
+    echo "  This means cgroup_lock eBPF enforcement is not active."
+    exit 1
 fi
 
 # Also check: is the helper still in zone A's cgroup (not zone B's)?


### PR DESCRIPTION
> Note: branched from a local `main` that was ahead of `origin/main`, so this PR
> bundles 9 commits — not just the README. Summary below.

## What this does

**Enforcement — fail closed**
- All 7 eBPF LSM hooks now return `-1` (EPERM) on their error path instead of `0`.
- `capable()` enforces zone capability policy; a policy with no `[capabilities]`
  section is **unrestricted** (allowlist is opt-in), error path fails closed.
- Linux daemon refuses to start without a working BPF-LSM kernel (no more silent
  degraded mode); recovery and zone creation fail closed if BPF maps can't be set.
- `create_zone` now rolls back fully on any failure (no partial zones).

**Policy hardening**
- `#[serde(deny_unknown_fields)]` across all policy structs — typo'd keys are
  rejected, not silently ignored.
- Capability-name validation + canonicalization (short form accepted).

**Observability**
- `rauha-evidence` crate: normalized evidence schema, projections, sinks.
- Enforcement events flow through it to the `WatchEvents` gRPC stream.

**Docs**
- README rewritten in the Syvä repo's style (badges, TOC, honest limitations).

## Review fixes applied (commit 53f9d1d)
- Restored `caps_mask == 0 => allow` so minimal policies don't deny every capability.
- Reordered map writes (policy before membership) to close a fail-closed `capable()` gap.
- Clarified the capability policy test; corrected README claims about degraded mode.

## Risk / follow-ups
- Behavior change: Linux now **requires** root + BPF-LSM to run. Confirm this is
  intended for all deploy targets; rootless dev moves to the macOS backend.
- `cgroup_attach_task` error path now blocks the cgroup move — only the rare
  probe-error path, but it sits on the container-startup path; validate with
  `tests/integration/test-cgroup-lock.sh`.
- eBPF + Linux backend must be validated on a privileged Linux host (can't link
  bpf objects or compile the Linux backend on macOS).