### PR TITLE
Fix container identity, PTY resize, and macOS stats

### DIFF
--- a/rauha-common/src/shim.rs
+++ b/rauha-common/src/shim.rs
@@ -47,32 +47,51 @@ pub enum ShimRequest {
         /// Whether to allocate a PTY for the exec process.
         pty: bool,
     },
+    /// Resize an active PTY session.
+    ResizePty {
+        id: String,
+        session_id: Option<String>,
+        rows: u32,
+        cols: u32,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ShimResponse {
     Ok,
-    Created { pid: u32 },
+    Created {
+        pid: u32,
+    },
     State {
         pid: u32,
         status: String,
         exit_code: Option<i32>,
     },
-    Error { message: String },
+    Error {
+        message: String,
+    },
     /// Zone-level resource usage statistics.
     Stats {
         cpu_usage_ns: u64,
         memory_bytes: u64,
         pids: u32,
+        container_count: u32,
+        network_rx_bytes: u64,
+        network_tx_bytes: u64,
     },
     /// An attach/exec session is ready. Connect to the socket at `socket_path`
     /// for bidirectional I/O with the container process.
-    AttachReady { socket_path: String },
+    AttachReady {
+        socket_path: String,
+        session_id: Option<String>,
+    },
     /// An exec session is ready. Connect via the appropriate transport for
     /// bidirectional I/O with the exec process.
     ///
     /// Linux shim sets `socket_path`; macOS guest agent sets `vsock_port`.
     ExecReady {
+        /// Internal session identifier used for follow-up control messages.
+        session_id: Option<String>,
         /// Unix socket path (Linux shim).
         socket_path: Option<String>,
         /// Vsock port number (macOS guest agent).
@@ -200,6 +219,12 @@ mod tests {
                 env: vec!["TERM=xterm".into()],
                 pty: true,
             },
+            ShimRequest::ResizePty {
+                id: "c1".into(),
+                session_id: Some("session-1".into()),
+                rows: 40,
+                cols: 120,
+            },
         ];
 
         for req in cases {
@@ -230,15 +255,21 @@ mod tests {
                 cpu_usage_ns: 1_000_000,
                 memory_bytes: 64 * 1024 * 1024,
                 pids: 5,
+                container_count: 2,
+                network_rx_bytes: 1024,
+                network_tx_bytes: 2048,
             },
             ShimResponse::AttachReady {
                 socket_path: "/run/rauha/containers/abc/attach-123.sock".into(),
+                session_id: Some("attach-123".into()),
             },
             ShimResponse::ExecReady {
+                session_id: Some("exec-456".into()),
                 socket_path: Some("/run/rauha/containers/abc/exec-456.sock".into()),
                 vsock_port: None,
             },
             ShimResponse::ExecReady {
+                session_id: Some("exec-vsock".into()),
                 socket_path: None,
                 vsock_port: Some(6001),
             },

--- a/rauha-guest-agent/src/attach.rs
+++ b/rauha-guest-agent/src/attach.rs
@@ -5,12 +5,20 @@
 //! - Vsock listener instead of Unix socket listener
 //! - Chroot into virtiofs-mounted rootfs at /mnt/rauha/containers/{id}/...
 
+#[cfg(target_os = "linux")]
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
+#[cfg(target_os = "linux")]
+use std::sync::{LazyLock, Mutex};
 
 /// Next available vsock port for exec sessions. Starts at 6000 to avoid
 /// conflict with the control port (5123).
 static NEXT_SESSION_PORT: AtomicU32 = AtomicU32::new(6000);
+
+#[cfg(target_os = "linux")]
+static PTY_SESSIONS: LazyLock<Mutex<HashMap<String, i32>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Allocate a unique vsock port for an exec session.
 pub fn allocate_session_port() -> u32 {
@@ -164,7 +172,11 @@ mod tests {
 ///
 /// The thread closes the PTY master fd when the session ends.
 #[cfg(target_os = "linux")]
-pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Result<()> {
+pub fn serve_vsock_session(
+    session_id: &str,
+    pty_master_fd: i32,
+    vsock_port: u32,
+) -> anyhow::Result<()> {
     use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
     use std::os::fd::BorrowedFd;
 
@@ -233,6 +245,12 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
     }
 
     tracing::info!(port = vsock_port, "exec session vsock listening");
+    let session_key = session_id.to_string();
+
+    PTY_SESSIONS
+        .lock()
+        .map_err(|_| anyhow::anyhow!("PTY session registry is poisoned"))?
+        .insert(session_key.clone(), pty_master_fd);
 
     // Spawn relay thread.
     std::thread::spawn(move || {
@@ -252,6 +270,9 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
                         port = vsock_port,
                         "exec session vsock accept timed out; closing PTY"
                     );
+                    if let Ok(mut sessions) = PTY_SESSIONS.lock() {
+                        sessions.remove(&session_key);
+                    }
                     unsafe {
                         libc::close(pty_master_fd);
                         libc::close(listen_fd);
@@ -262,6 +283,9 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
                 Err(nix::errno::Errno::EINTR) => continue,
                 Err(e) => {
                     tracing::error!(%e, "exec session vsock poll failed");
+                    if let Ok(mut sessions) = PTY_SESSIONS.lock() {
+                        sessions.remove(&session_key);
+                    }
                     unsafe {
                         libc::close(pty_master_fd);
                         libc::close(listen_fd);
@@ -279,6 +303,9 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
                 continue;
             }
             tracing::error!(%err, "exec session vsock accept failed");
+            if let Ok(mut sessions) = PTY_SESSIONS.lock() {
+                sessions.remove(&session_key);
+            }
             unsafe {
                 libc::close(pty_master_fd);
                 libc::close(listen_fd);
@@ -372,12 +399,42 @@ pub fn serve_vsock_session(pty_master_fd: i32, vsock_port: u32) -> anyhow::Resul
             }
         }
 
+        if let Ok(mut sessions) = PTY_SESSIONS.lock() {
+            sessions.remove(&session_key);
+        }
         unsafe {
             libc::close(pty_master_fd);
             libc::close(conn_fd);
         }
         tracing::debug!(port = vsock_port, "exec session ended");
     });
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn resize_pty(session_id: &str, rows: u32, cols: u32) -> anyhow::Result<()> {
+    if rows == 0 || cols == 0 || rows > u16::MAX as u32 || cols > u16::MAX as u32 {
+        anyhow::bail!("invalid PTY size {rows}x{cols}");
+    }
+
+    let pty_master_fd = *PTY_SESSIONS
+        .lock()
+        .map_err(|_| anyhow::anyhow!("PTY session registry is poisoned"))?
+        .get(session_id)
+        .ok_or_else(|| anyhow::anyhow!("PTY session {session_id} not found"))?;
+
+    let winsize = libc::winsize {
+        ws_row: rows as u16,
+        ws_col: cols as u16,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+
+    let ret = unsafe { libc::ioctl(pty_master_fd, libc::TIOCSWINSZ, &winsize) };
+    if ret < 0 {
+        anyhow::bail!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
+    }
 
     Ok(())
 }
@@ -407,6 +464,15 @@ pub fn fork_and_exec_pty(
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn serve_vsock_session(_pty_master_fd: i32, _vsock_port: u32) -> anyhow::Result<()> {
+pub fn serve_vsock_session(
+    _session_id: &str,
+    _pty_master_fd: i32,
+    _vsock_port: u32,
+) -> anyhow::Result<()> {
     anyhow::bail!("vsock sessions are only supported inside Linux VMs")
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn resize_pty(_session_id: &str, _rows: u32, _cols: u32) -> anyhow::Result<()> {
+    anyhow::bail!("PTY resize is only supported inside Linux VMs")
 }

--- a/rauha-guest-agent/src/container.rs
+++ b/rauha-guest-agent/src/container.rs
@@ -234,11 +234,18 @@ fn redirect_stdio(log_dir: &Path) {
 }
 
 /// Collect resource usage stats for all processes in this VM.
-pub fn collect_stats() -> (u64, u64, u32) {
+pub fn collect_stats() -> (u64, u64, u32, u64, u64) {
     let cpu_usage_ns = read_proc_stat_cpu_ns().unwrap_or(0);
     let memory_bytes = read_meminfo_used().unwrap_or(0);
     let pids = count_pids().unwrap_or(0);
-    (cpu_usage_ns, memory_bytes, pids)
+    let (network_rx_bytes, network_tx_bytes) = read_network_bytes().unwrap_or((0, 0));
+    (
+        cpu_usage_ns,
+        memory_bytes,
+        pids,
+        network_rx_bytes,
+        network_tx_bytes,
+    )
 }
 
 fn read_proc_stat_cpu_ns() -> Option<u64> {
@@ -274,17 +281,41 @@ fn parse_meminfo_kb(s: &str) -> Option<u64> {
 
 fn count_pids() -> Option<u32> {
     let mut count = 0u32;
-    for entry in std::fs::read_dir("/proc").ok()? {
-        if let Ok(entry) = entry {
-            if entry
-                .file_name()
-                .to_string_lossy()
-                .chars()
-                .all(|c| c.is_ascii_digit())
-            {
-                count += 1;
-            }
+    for entry in (std::fs::read_dir("/proc").ok()?).flatten() {
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .chars()
+            .all(|c| c.is_ascii_digit())
+        {
+            count += 1;
         }
     }
     Some(count)
+}
+
+fn read_network_bytes() -> Option<(u64, u64)> {
+    let data = std::fs::read_to_string("/proc/net/dev").ok()?;
+    let mut rx = 0u64;
+    let mut tx = 0u64;
+
+    for line in data.lines().skip(2) {
+        let Some((iface, counters)) = line.split_once(':') else {
+            continue;
+        };
+        let iface = iface.trim();
+        if iface == "lo" {
+            continue;
+        }
+
+        let fields: Vec<&str> = counters.split_whitespace().collect();
+        if fields.len() < 16 {
+            continue;
+        }
+
+        rx = rx.saturating_add(fields[0].parse::<u64>().unwrap_or(0));
+        tx = tx.saturating_add(fields[8].parse::<u64>().unwrap_or(0));
+    }
+
+    Some((rx, tx))
 }

--- a/rauha-guest-agent/src/main.rs
+++ b/rauha-guest-agent/src/main.rs
@@ -116,6 +116,10 @@ impl AgentState {
             }
         }
     }
+
+    fn container_count(&self) -> u32 {
+        self.containers.len() as u32
+    }
 }
 
 fn handle_request(state: &mut AgentState, request: ShimRequest) -> ShimResponse {
@@ -153,11 +157,33 @@ fn handle_request(state: &mut AgentState, request: ShimRequest) -> ShimResponse 
             ShimResponse::Ok
         }
         ShimRequest::GetStats => {
-            let (cpu_usage_ns, memory_bytes, pids) = container::collect_stats();
+            let (cpu_usage_ns, memory_bytes, pids, network_rx_bytes, network_tx_bytes) =
+                container::collect_stats();
             ShimResponse::Stats {
                 cpu_usage_ns,
                 memory_bytes,
                 pids,
+                container_count: state.container_count(),
+                network_rx_bytes,
+                network_tx_bytes,
+            }
+        }
+        ShimRequest::ResizePty {
+            id,
+            session_id,
+            rows,
+            cols,
+        } => {
+            let Some(session_id) = session_id else {
+                return ShimResponse::Error {
+                    message: format!("missing PTY session id for container {id}"),
+                };
+            };
+            match attach::resize_pty(&session_id, rows, cols) {
+                Ok(()) => ShimResponse::Ok,
+                Err(e) => ShimResponse::Error {
+                    message: e.to_string(),
+                },
             }
         }
         ShimRequest::Attach { .. } => ShimResponse::Error {
@@ -193,17 +219,21 @@ fn handle_request(state: &mut AgentState, request: ShimRequest) -> ShimResponse 
             }
 
             let vsock_port = attach::allocate_session_port();
+            let session_id = format!("vsock-{vsock_port}");
 
             match attach::fork_and_exec_pty(&state.rootfs_root, &id, &command, &env) {
-                Ok((master_fd, _pid)) => match attach::serve_vsock_session(master_fd, vsock_port) {
-                    Ok(()) => ShimResponse::ExecReady {
-                        socket_path: None,
-                        vsock_port: Some(vsock_port),
-                    },
-                    Err(e) => ShimResponse::Error {
-                        message: format!("failed to create vsock session: {e}"),
-                    },
-                },
+                Ok((master_fd, _pid)) => {
+                    match attach::serve_vsock_session(&session_id, master_fd, vsock_port) {
+                        Ok(()) => ShimResponse::ExecReady {
+                            session_id: Some(session_id),
+                            socket_path: None,
+                            vsock_port: Some(vsock_port),
+                        },
+                        Err(e) => ShimResponse::Error {
+                            message: format!("failed to create vsock session: {e}"),
+                        },
+                    }
+                }
                 Err(e) => ShimResponse::Error {
                     message: format!("exec failed: {e}"),
                 },

--- a/rauha-shim/src/attach.rs
+++ b/rauha-shim/src/attach.rs
@@ -9,6 +9,15 @@
 
 use std::path::Path;
 
+#[cfg(target_os = "linux")]
+use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::sync::{LazyLock, Mutex};
+
+#[cfg(target_os = "linux")]
+static PTY_SESSIONS: LazyLock<Mutex<HashMap<String, i32>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 /// Create an attach session socket and spawn a relay thread.
 ///
 /// Returns the socket path. The caller (daemon) connects to this socket
@@ -37,6 +46,12 @@ pub fn serve_attach_session(
 
     let listener = UnixListener::bind(&socket_path)?;
     let path_str = socket_path.to_string_lossy().to_string();
+    let session_key = session_id.to_string();
+
+    PTY_SESSIONS
+        .lock()
+        .map_err(|_| anyhow::anyhow!("PTY session registry is poisoned"))?
+        .insert(session_key.clone(), pty_master_fd);
 
     // Spawn a dedicated thread for this attach session.
     std::thread::spawn(move || {
@@ -45,6 +60,12 @@ pub fn serve_attach_session(
             Ok((stream, _)) => stream,
             Err(e) => {
                 tracing::error!(%e, "attach session accept failed");
+                if let Ok(mut sessions) = PTY_SESSIONS.lock() {
+                    sessions.remove(&session_key);
+                }
+                unsafe {
+                    libc::close(pty_master_fd);
+                }
                 return;
             }
         };
@@ -125,6 +146,10 @@ pub fn serve_attach_session(
             }
         }
 
+        if let Ok(mut sessions) = PTY_SESSIONS.lock() {
+            sessions.remove(&session_key);
+        }
+
         // Close PTY master fd now that the relay is done.
         unsafe {
             libc::close(pty_master_fd);
@@ -136,6 +161,33 @@ pub fn serve_attach_session(
     });
 
     Ok(path_str)
+}
+
+#[cfg(target_os = "linux")]
+pub fn resize_pty(session_id: &str, rows: u32, cols: u32) -> anyhow::Result<()> {
+    if rows == 0 || cols == 0 || rows > u16::MAX as u32 || cols > u16::MAX as u32 {
+        anyhow::bail!("invalid PTY size {rows}x{cols}");
+    }
+
+    let pty_master_fd = *PTY_SESSIONS
+        .lock()
+        .map_err(|_| anyhow::anyhow!("PTY session registry is poisoned"))?
+        .get(session_id)
+        .ok_or_else(|| anyhow::anyhow!("PTY session {session_id} not found"))?;
+
+    let winsize = libc::winsize {
+        ws_row: rows as u16,
+        ws_col: cols as u16,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+
+    let ret = unsafe { libc::ioctl(pty_master_fd, libc::TIOCSWINSZ, &winsize) };
+    if ret < 0 {
+        anyhow::bail!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
+    }
+
+    Ok(())
 }
 
 /// Write all bytes to a raw fd.
@@ -313,6 +365,11 @@ pub fn serve_attach_session(
     _pty_master_fd: i32,
 ) -> anyhow::Result<String> {
     anyhow::bail!("attach sessions are only supported on Linux")
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn resize_pty(_session_id: &str, _rows: u32, _cols: u32) -> anyhow::Result<()> {
+    anyhow::bail!("PTY resize is only supported on Linux")
 }
 
 /// Non-Linux stub.

--- a/rauha-shim/src/main.rs
+++ b/rauha-shim/src/main.rs
@@ -13,7 +13,10 @@ use tracing_subscriber::EnvFilter;
 use crate::state::ShimState;
 
 #[derive(Parser)]
-#[command(name = "rauha-shim", about = "Zone shim — one per zone, runs container processes")]
+#[command(
+    name = "rauha-shim",
+    about = "Zone shim — one per zone, runs container processes"
+)]
 struct Args {
     /// Zone name.
     #[arg(long)]
@@ -30,9 +33,7 @@ struct Args {
 
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::from_default_env().add_directive("rauha_shim=info".parse()?),
-        )
+        .with_env_filter(EnvFilter::from_default_env().add_directive("rauha_shim=info".parse()?))
         .init();
 
     let args = Args::parse();
@@ -70,9 +71,7 @@ fn main() -> anyhow::Result<()> {
                             tracing::error!(%e, "failed to send response");
                         }
                         // Check for shutdown.
-                        if matches!(response, ShimResponse::Ok)
-                            && shim_state.should_shutdown()
-                        {
+                        if matches!(response, ShimResponse::Ok) && shim_state.should_shutdown() {
                             tracing::info!("shutting down");
                             break;
                         }
@@ -147,11 +146,32 @@ fn handle_request(state: &mut ShimState, request: ShimRequest) -> ShimResponse {
             ShimResponse::Ok
         }
         ShimRequest::GetStats => {
-            let (pids, _) = state.container_summary();
+            let (pids, container_count) = state.container_summary();
             ShimResponse::Stats {
-                cpu_usage_ns: 0,    // TODO: read from cgroup
-                memory_bytes: 0,    // TODO: read from cgroup
+                cpu_usage_ns: 0, // TODO: read from cgroup
+                memory_bytes: 0, // TODO: read from cgroup
                 pids,
+                container_count,
+                network_rx_bytes: 0,
+                network_tx_bytes: 0,
+            }
+        }
+        ShimRequest::ResizePty {
+            id,
+            session_id,
+            rows,
+            cols,
+        } => {
+            let Some(session_id) = session_id else {
+                return ShimResponse::Error {
+                    message: format!("missing PTY session id for container {id}"),
+                };
+            };
+            match attach::resize_pty(&session_id, rows, cols) {
+                Ok(()) => ShimResponse::Ok,
+                Err(e) => ShimResponse::Error {
+                    message: e.to_string(),
+                },
             }
         }
         ShimRequest::Exec {
@@ -168,7 +188,7 @@ fn handle_request(state: &mut ShimState, request: ShimRequest) -> ShimResponse {
             }
             let session_id = uuid::Uuid::new_v4().to_string();
             match attach::fork_and_exec_pty(
-                &state.zone_name(),
+                state.zone_name(),
                 &id,
                 &command,
                 &env,
@@ -177,6 +197,7 @@ fn handle_request(state: &mut ShimState, request: ShimRequest) -> ShimResponse {
                 Ok((master_fd, _pid)) => {
                     match attach::serve_attach_session(&id, &session_id, master_fd) {
                         Ok(socket_path) => ShimResponse::ExecReady {
+                            session_id: Some(session_id),
                             socket_path: Some(socket_path),
                             vsock_port: None,
                         },
@@ -196,7 +217,8 @@ fn handle_request(state: &mut ShimState, request: ShimRequest) -> ShimResponse {
             // to have been started with a PTY. For now, return not supported
             // since Phase 3 containers use log-file stdio.
             ShimResponse::Error {
-                message: "attach to non-PTY container not supported — use `exec -it` instead".into(),
+                message: "attach to non-PTY container not supported — use `exec -it` instead"
+                    .into(),
             }
         }
     }

--- a/rauhad/src/backend/macos/mod.rs
+++ b/rauhad/src/backend/macos/mod.rs
@@ -281,29 +281,23 @@ impl IsolationBackend for MacosBackend {
                 cpu_usage_ns,
                 memory_bytes,
                 pids,
+                container_count,
+                network_rx_bytes,
+                network_tx_bytes,
             }) => Ok(ZoneStats {
                 zone_id: zone.id,
-                container_count: 0, // TODO: track container count
+                container_count,
                 cpu_usage_percent: cpu_usage_ns as f64 / 1_000_000_000.0,
                 memory_usage_bytes: memory_bytes,
                 memory_limit_bytes: 0, // Set from policy
-                network_rx_bytes: 0,   // TODO: track network stats
-                network_tx_bytes: 0,
+                network_rx_bytes,
+                network_tx_bytes,
                 pids_current: pids as u64,
             }),
-            Ok(_) | Err(_) => {
-                // Fallback: return zeroed stats if guest agent isn't reachable.
-                Ok(ZoneStats {
-                    zone_id: zone.id,
-                    container_count: 0,
-                    cpu_usage_percent: 0.0,
-                    memory_usage_bytes: 0,
-                    memory_limit_bytes: 0,
-                    network_rx_bytes: 0,
-                    network_tx_bytes: 0,
-                    pids_current: 0,
-                })
-            }
+            Ok(other) => Err(RauhaError::BackendError(format!(
+                "unexpected response to GetStats: {other:?}"
+            ))),
+            Err(e) => Err(e),
         }
     }
 

--- a/rauhad/src/server.rs
+++ b/rauhad/src/server.rs
@@ -512,13 +512,18 @@ impl ContainerService for ContainerServiceImpl {
             .registry
             .get_container(&container_id)
             .map_err(to_status)?;
+        let zone_name = self
+            .registry
+            .zone_name_for_container(&container.zone_id)
+            .await
+            .ok_or_else(|| Status::internal("zone not found for container"))?;
 
         Ok(Response::new(pb::container::GetContainerResponse {
             container: Some(pb::container::ContainerInfo {
                 id: container.id.to_string(),
                 name: container.name,
                 zone_id: container.zone_id.to_string(),
-                zone_name: String::new(), // TODO: reverse lookup
+                zone_name,
                 image: container.image,
                 state: format!("{:?}", container.state),
                 pid: container.pid.unwrap_or(0),
@@ -547,20 +552,25 @@ impl ContainerService for ContainerServiceImpl {
             .list_containers(zone_filter)
             .map_err(to_status)?;
 
-        let infos = containers
-            .into_iter()
-            .map(|c| pb::container::ContainerInfo {
+        let mut infos = Vec::with_capacity(containers.len());
+        for c in containers {
+            let zone_name = self
+                .registry
+                .zone_name_for_container(&c.zone_id)
+                .await
+                .ok_or_else(|| Status::internal("zone not found for container"))?;
+            infos.push(pb::container::ContainerInfo {
                 id: c.id.to_string(),
                 name: c.name,
                 zone_id: c.zone_id.to_string(),
-                zone_name: String::new(), // TODO: reverse lookup
+                zone_name,
                 image: c.image,
                 state: format!("{:?}", c.state),
                 pid: c.pid.unwrap_or(0),
                 created_at: c.created_at.to_rfc3339(),
                 started_at: c.started_at.map(|t| t.to_rfc3339()).unwrap_or_default(),
-            })
-            .collect();
+            });
+        }
 
         Ok(Response::new(pb::container::ListContainersResponse {
             containers: infos,
@@ -680,6 +690,7 @@ impl ContainerService for ContainerServiceImpl {
         // The transport differs by platform but the relay logic is identical.
         match response {
             rauha_common::shim::ShimResponse::ExecReady {
+                session_id,
                 socket_path: Some(path),
                 ..
             } => {
@@ -687,9 +698,21 @@ impl ContainerService for ContainerServiceImpl {
                     Status::internal(format!("failed to connect to exec socket: {e}"))
                 })?;
                 let (r, w) = stream.into_split();
-                spawn_exec_relay(r, w, tx, in_stream);
+                spawn_exec_relay(
+                    r,
+                    w,
+                    tx,
+                    in_stream,
+                    Some(PtyResizeTarget {
+                        registry: self.registry.clone(),
+                        zone_name: zone_name.clone(),
+                        container_id: container_id.to_string(),
+                        session_id,
+                    }),
+                );
             }
             rauha_common::shim::ShimResponse::ExecReady {
+                session_id,
                 vsock_port: Some(port),
                 ..
             } => {
@@ -701,17 +724,42 @@ impl ContainerService for ContainerServiceImpl {
                         Status::internal(format!("failed to connect exec vsock: {e}"))
                     })?;
                 let (r, w) = tokio::io::split(stream);
-                spawn_exec_relay(r, w, tx, in_stream);
+                spawn_exec_relay(
+                    r,
+                    w,
+                    tx,
+                    in_stream,
+                    Some(PtyResizeTarget {
+                        registry: self.registry.clone(),
+                        zone_name: zone_name.clone(),
+                        container_id: container_id.to_string(),
+                        session_id,
+                    }),
+                );
             }
             // Legacy: accept AttachReady for backward compat with older shims.
-            rauha_common::shim::ShimResponse::AttachReady { socket_path } => {
+            rauha_common::shim::ShimResponse::AttachReady {
+                socket_path,
+                session_id,
+            } => {
                 let stream = tokio::net::UnixStream::connect(&socket_path)
                     .await
                     .map_err(|e| {
                         Status::internal(format!("failed to connect to attach socket: {e}"))
                     })?;
                 let (r, w) = stream.into_split();
-                spawn_exec_relay(r, w, tx, in_stream);
+                spawn_exec_relay(
+                    r,
+                    w,
+                    tx,
+                    in_stream,
+                    Some(PtyResizeTarget {
+                        registry: self.registry.clone(),
+                        zone_name: zone_name.clone(),
+                        container_id: container_id.to_string(),
+                        session_id,
+                    }),
+                );
             }
             rauha_common::shim::ShimResponse::Error { message } => {
                 return Err(Status::internal(format!("exec failed: {message}")));
@@ -769,7 +817,10 @@ impl ContainerService for ContainerServiceImpl {
             .map_err(|e| Status::internal(format!("shim attach failed: {e}")))?;
 
         match response {
-            rauha_common::shim::ShimResponse::AttachReady { socket_path } => {
+            rauha_common::shim::ShimResponse::AttachReady {
+                socket_path,
+                session_id,
+            } => {
                 let stream = tokio::net::UnixStream::connect(&socket_path)
                     .await
                     .map_err(|e| {
@@ -778,6 +829,12 @@ impl ContainerService for ContainerServiceImpl {
 
                 let (read_half, write_half) = stream.into_split();
                 let (tx, rx) = mpsc::channel(256);
+                let resize_target = PtyResizeTarget {
+                    registry: self.registry.clone(),
+                    zone_name,
+                    container_id: container_id.to_string(),
+                    session_id,
+                };
 
                 tokio::spawn(async move {
                     use tokio::io::AsyncReadExt;
@@ -813,8 +870,8 @@ impl ContainerService for ContainerServiceImpl {
                                     break;
                                 }
                             }
-                            Some(pb::container::attach_request::Message::Resize(_resize)) => {
-                                // TODO: send TIOCSWINSZ to PTY via shim
+                            Some(pb::container::attach_request::Message::Resize(resize)) => {
+                                resize_target.resize(resize.rows, resize.cols).await;
                             }
                             _ => {}
                         }
@@ -840,6 +897,7 @@ fn spawn_exec_relay<R, W>(
     writer: W,
     tx: mpsc::Sender<Result<pb::container::ExecStreamResponse, Status>>,
     in_stream: Streaming<pb::container::ExecStreamRequest>,
+    resize_target: Option<PtyResizeTarget>,
 ) where
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
     W: tokio::io::AsyncWrite + Unpin + Send + 'static,
@@ -883,13 +941,62 @@ fn spawn_exec_relay<R, W>(
                         break;
                     }
                 }
-                Some(pb::container::exec_stream_request::Message::Resize(_resize)) => {
-                    // TODO: send TIOCSWINSZ to PTY via shim
+                Some(pb::container::exec_stream_request::Message::Resize(resize)) => {
+                    if let Some(target) = &resize_target {
+                        target.resize(resize.rows, resize.cols).await;
+                    }
                 }
                 _ => {}
             }
         }
     });
+}
+
+#[derive(Clone)]
+struct PtyResizeTarget {
+    registry: Arc<ZoneRegistry>,
+    zone_name: String,
+    container_id: String,
+    session_id: Option<String>,
+}
+
+impl PtyResizeTarget {
+    async fn resize(&self, rows: u32, cols: u32) {
+        let request = rauha_common::shim::ShimRequest::ResizePty {
+            id: self.container_id.clone(),
+            session_id: self.session_id.clone(),
+            rows,
+            cols,
+        };
+
+        match self.registry.shim_request(&self.zone_name, &request).await {
+            Ok(rauha_common::shim::ShimResponse::Ok) => {}
+            Ok(rauha_common::shim::ShimResponse::Error { message }) => {
+                tracing::warn!(
+                    zone = %self.zone_name,
+                    container = %self.container_id,
+                    error = %message,
+                    "PTY resize failed"
+                );
+            }
+            Ok(other) => {
+                tracing::warn!(
+                    zone = %self.zone_name,
+                    container = %self.container_id,
+                    response = ?other,
+                    "unexpected PTY resize response"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    zone = %self.zone_name,
+                    container = %self.container_id,
+                    error = %e,
+                    "PTY resize request failed"
+                );
+            }
+        }
+    }
 }
 
 // --- Image Service ---


### PR DESCRIPTION
## Summary
- populate container responses with zone names instead of empty placeholders
- forward exec/attach resize requests through internal shim IPC to TIOCSWINSZ on active PTY sessions
- return macOS VM stats from the guest agent for container count and network bytes, and surface guest stats failures instead of fabricating zeroes

## Verification
- cargo check -p rauha-common -p rauhad -p rauha-shim -p rauha-guest-agent
- cargo test -p rauha-common -p rauhad -p rauha-shim -p rauha-guest-agent
- cargo clippy -p rauha-common -p rauhad -p rauha-shim -p rauha-guest-agent --all-targets (passes with existing warnings)
- limactl shell syva-dev -- cargo check -p rauha-common -p rauhad -p rauha-shim -p rauha-guest-agent

## Notes
- Public gRPC/proto surface is unchanged; only internal shim IPC is extended.
- PTY resize and Linux guest-agent stats compile in Lima; runtime PTY resize still needs privileged/container integration verification.
- Existing clippy -D warnings is blocked by pre-existing lints, starting with rauha-common/src/zone.rs ZonePolicy derivable_impls.
