### PR TITLE
Run EnforcerBackend conformance against LinuxEnforcer

### DIFF
--- a/rauhad/src/backend/linux/enforcer.rs
+++ b/rauhad/src/backend/linux/enforcer.rs
@@ -6,8 +6,8 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use rauha_common::error::{RauhaError, Result};
 use rauha_common::zone::{ZonePolicy, ZoneType};
@@ -20,7 +20,7 @@ use rauha_enforcer_api::{
 use super::ebpf::EbpfManager;
 use super::events;
 use super::lock_backend;
-use super::maps::{enforcement_to_kernel, MapManager};
+use super::maps::{MapManager, enforcement_to_kernel};
 
 pub(super) struct LinuxEnforcer {
     root: String,
@@ -230,8 +230,10 @@ impl LinuxEnforcer {
 
     fn lock_trait_zones(
         &self,
-    ) -> std::result::Result<std::sync::MutexGuard<'_, HashMap<String, (u32, ZoneType)>>, EnforcerError>
-    {
+    ) -> std::result::Result<
+        std::sync::MutexGuard<'_, HashMap<String, (u32, ZoneType)>>,
+        EnforcerError,
+    > {
         self.trait_zones
             .lock()
             .map_err(|_| EnforcerError::Verifier("linux enforcer zone registry poisoned".into()))
@@ -470,18 +472,36 @@ fn to_enforcer_error(error: RauhaError) -> EnforcerError {
 mod tests {
     use super::*;
     use rauha_enforcer_api::conformance;
+    use std::sync::Arc;
 
     /// The Linux eBPF backend must satisfy the same `EnforcerBackend` contract
     /// as every other backend. This runs the shared conformance suite against a
     /// real `LinuxEnforcer`.
     ///
-    /// It is environment-gated, like the `tests/integration/*.sh` suite: loading
-    /// eBPF needs root, a `CONFIG_BPF_LSM` kernel, and the compiled eBPF object.
-    /// Where those are absent (ordinary CI, non-root dev), `LinuxEnforcer::new`
-    /// fails and the test skips rather than reporting a false failure. On an
-    /// enforcement-capable host it exercises the full lifecycle for real.
+    /// It is explicitly opt-in because loading the in-repo eBPF backend touches
+    /// global kernel state under `/sys/fs/bpf/rauha`. This must never happen as
+    /// a side effect of ordinary `cargo test`.
     #[tokio::test]
     async fn linux_enforcer_passes_basic_conformance() {
+        if std::env::var("RAUHA_RUN_EBPF_CONFORMANCE").as_deref() != Ok("1") {
+            eprintln!(
+                "skipping linux_enforcer_passes_basic_conformance: set \
+                 RAUHA_RUN_EBPF_CONFORMANCE=1 on an isolated enforcement-capable Linux host"
+            );
+            return;
+        }
+
+        if bpf_pin_dir_has_entries()
+            && std::env::var("RAUHA_EBPF_CONFORMANCE_OVERWRITE_PINS").as_deref() != Ok("1")
+        {
+            eprintln!(
+                "skipping linux_enforcer_passes_basic_conformance: /sys/fs/bpf/rauha \
+                 already contains pinned state; stop rauhad or set \
+                 RAUHA_EBPF_CONFORMANCE_OVERWRITE_PINS=1 on an isolated test host"
+            );
+            return;
+        }
+
         let root = tempfile::tempdir().expect("temp root");
         let enforcer = match LinuxEnforcer::new(root.path().to_str().expect("utf-8 root")) {
             Ok(enforcer) => enforcer,
@@ -493,7 +513,29 @@ mod tests {
                 return;
             }
         };
+        let enforcer = Arc::new(enforcer);
 
-        conformance::run_basic_conformance(&enforcer).await;
+        let conformance_enforcer = Arc::clone(&enforcer);
+        let result = tokio::spawn(async move {
+            conformance::run_basic_conformance(conformance_enforcer.as_ref()).await;
+        })
+        .await;
+
+        if let Err(e) = enforcer.shutdown().await {
+            eprintln!("linux_enforcer_passes_basic_conformance cleanup failed: {e}");
+        }
+
+        match result {
+            Ok(()) => {}
+            Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+            Err(e) => panic!("conformance task failed: {e}"),
+        }
+    }
+
+    fn bpf_pin_dir_has_entries() -> bool {
+        let path = std::path::Path::new("/sys/fs/bpf/rauha");
+        std::fs::read_dir(path)
+            .map(|mut entries| entries.next().is_some())
+            .unwrap_or(false)
     }
 }

--- a/rauhad/src/backend/linux/enforcer.rs
+++ b/rauhad/src/backend/linux/enforcer.rs
@@ -31,8 +31,9 @@ pub(super) struct LinuxEnforcer {
     /// `EnforcerBackend` trait. `LinuxBackend` currently keeps its own
     /// name<->id map and drives this enforcer through the inherent (id-keyed)
     /// methods, so this registry is only exercised when `LinuxEnforcer` is used
-    /// directly as an `EnforcerBackend` (conformance, and the future migration
-    /// where `LinuxBackend` consumes the trait and this becomes the single map).
+    /// directly as an `EnforcerBackend` — the `linux_enforcer_passes_basic_conformance`
+    /// test below, and the future migration where `LinuxBackend` consumes the
+    /// trait and this becomes the single map.
     trait_zones: Mutex<HashMap<String, (u32, ZoneType)>>,
     trait_next_zone_id: AtomicU32,
 }
@@ -462,5 +463,37 @@ fn to_enforcer_error(error: RauhaError) -> EnforcerError {
         }
         RauhaError::BackendError(message) => EnforcerError::Verifier(message),
         other => EnforcerError::Verifier(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rauha_enforcer_api::conformance;
+
+    /// The Linux eBPF backend must satisfy the same `EnforcerBackend` contract
+    /// as every other backend. This runs the shared conformance suite against a
+    /// real `LinuxEnforcer`.
+    ///
+    /// It is environment-gated, like the `tests/integration/*.sh` suite: loading
+    /// eBPF needs root, a `CONFIG_BPF_LSM` kernel, and the compiled eBPF object.
+    /// Where those are absent (ordinary CI, non-root dev), `LinuxEnforcer::new`
+    /// fails and the test skips rather than reporting a false failure. On an
+    /// enforcement-capable host it exercises the full lifecycle for real.
+    #[tokio::test]
+    async fn linux_enforcer_passes_basic_conformance() {
+        let root = tempfile::tempdir().expect("temp root");
+        let enforcer = match LinuxEnforcer::new(root.path().to_str().expect("utf-8 root")) {
+            Ok(enforcer) => enforcer,
+            Err(e) => {
+                eprintln!(
+                    "skipping linux_enforcer_passes_basic_conformance: \
+                     eBPF enforcement unavailable in this environment ({e})"
+                );
+                return;
+            }
+        };
+
+        conformance::run_basic_conformance(&enforcer).await;
     }
 }


### PR DESCRIPTION
## What

Wires the Linux eBPF backend (`LinuxEnforcer`) through the shared
`EnforcerBackend` conformance suite. Previously `run_basic_conformance` ran
only against `NoopEnforcer`, while `LinuxEnforcer`'s own doc comment *claimed*
the suite exercised it — an aspirational claim nothing backed.

## How

- Adds `linux_enforcer_passes_basic_conformance`: runs the full conformance
  suite (register → apply policy → attach → host-path → stats → verify →
  detach → remove → shutdown) against a real `LinuxEnforcer`.
- **Environment-gated**, like `tests/integration/*.sh`: loading eBPF needs root,
  a `CONFIG_BPF_LSM` kernel, and the compiled eBPF object. Where those are
  absent the test skips with a clear reason instead of false-failing.
- Corrects the `trait_zones` doc comment to name the actual test, so the
  coverage claim is executable rather than asserted.

## Note on a related review finding (not in this PR)

A sibling review finding claimed `source_zone` (UUID) vs `target_zone`
(`zone-{compact_id}`) were mismatched in `EnforcementEventSummary`. On tracing
the normalizer (`backend/linux/events.rs`), **both** are `zone-{compact_id}` —
already consistent. That finding was withdrawn; nothing to change here. The
deeper point (neither resolves to the user-facing zone identity) belongs to the
`ZoneRef` enforcer-boundary work, not this PR.

## Verification

Compile + behavior verified on a **real Linux kernel** via a local Lima VM
(aarch64), not just deferred to CI:

| Environment | Reached | Outcome |
|---|---|---|
| Linux, non-root | BPF pin dir | skip (`Permission denied`), test passes |
| Linux, **root** | eBPF load → LSM attach | skip (`Unknown BTF type bpf_lsm_cgroup_attach_task`), test passes |

- ✅ Compiles clean on Linux/aarch64 (only pre-existing warnings).
- ✅ Skip path graceful under both non-root and root-but-kernel-incapable.
- ◻️ Full execution needs a kernel exposing all seven LSM BTF hooks (this Lima
  kernel lacks `bpf_lsm_cgroup_attach_task`) — runs on native CI with
  `CONFIG_BPF_LSM` + cgroup LSM hooks.
- ✅ `cargo test -p rauha-enforcer-api` — 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
