### PR TITLE
Correct README enforcement claims (socket audit-only, seam status)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ flowchart TB
         cgroups["cgroups v2"]
         ns["namespaces + netns"]
         rootfs["OCI rootfs + rauha-shim"]
-        syva["Syvä / BPF-LSM\nfile · exec · ptrace · signal · cgroup · net"]
+        syva["Syvä / BPF-LSM — 6 enforcing hooks\nfile · exec · ptrace · signal · cgroup · capability\n+ socket (audit-only; nftables enforces network)"]
         maps["BPF maps\nzone membership · policy · inode ownership"]
         ring["BPF ring buffer\nenforcement events"]
 
@@ -291,15 +291,19 @@ the VM itself, so no cgroups or namespaces are needed.
 | --- | --- |
 | Runtime lifecycle, zone create/delete | Linux kernel enforcement (BPF-LSM) |
 | Sandbox/container execution | eBPF programs, BPF maps, ring-buffer events |
-| Policy loading and validation | file / exec / ptrace / signal / socket deny decisions |
+| Policy loading and validation | file / exec / ptrace / signal / cgroup / capability deny decisions (socket is audit-only; nftables enforces network) |
 | Image, rootfs, networking, metadata | per-hook counters and privileged self-tests |
 | Logs, audit, user-facing event surfaces | the in-kernel deny-before-it-happens decision |
 | Kubernetes / containerd integration | |
 
 Syvä is a separate product ([`github.com/false-systems/syva`](https://github.com/false-systems/syva)).
-Current Linux eBPF code may still live in this repository, but architecturally it
-now sits behind the `rauha-enforcer-api` boundary; the `rauha-enforce` crate is
-a legacy seed and is not extended. See
+The `rauha-enforcer-api` crate defines this boundary as a backend-neutral trait,
+with a `NoopEnforcer` and a shared conformance harness every backend must pass.
+Be precise about today's state: the in-repo Linux eBPF backend is the
+implementation the daemon actually runs, an external Syvä backend is not yet
+wired in, and routing the daemon's live enforcement entirely through the trait
+is still in progress. **The seam is real, but not yet the sole enforcement
+path.** The `rauha-enforce` crate is a legacy seed and is not extended. See
 [`docs/rauha-syva-boundary.md`](docs/rauha-syva-boundary.md).
 
 ## Limitations (honest)


### PR DESCRIPTION
## What

Brings the README in line with what the code actually does at the enforcement
boundary. Two accuracy fixes plus the doc rewrite that started this branch.

## Why

The README had drifted in the optimistic direction on two independent axes —
describing the intended end-state as if it were today's state:

1. **`socket` was presented as an enforcing LSM hook.** It isn't:
   `rauha-ebpf/src/socket_connect_guard.rs` is **audit-only** (returns `0`
   always; emits an event). Network enforcement is **nftables**. The
   architecture diagram also silently omitted the `capable` hook.

2. **The `rauha-enforcer-api` seam was implied to be the enforcement path.**
   The seam exists (with `NoopEnforcer` + a shared conformance harness), but the
   in-repo Linux eBPF backend is what the daemon actually runs, and routing the
   live path entirely through the trait is still in progress.

## Changes

- **Architecture diagram** → lists the **6 enforcing hooks**
  (file / exec / ptrace / signal / cgroup / capability) and marks
  **socket audit-only (nftables enforces network)**.
- **Syvä ownership table** → same correction; no longer calls socket a deny
  decision.
- **Syvä section** → an honest status line:
  *"The seam is real, but not yet the sole enforcement path."*
- (from `057931c`) conformance section documents the opt-in
  `RAUHA_RUN_EBPF_CONFORMANCE=1` test + pinned-BPF-state guard; crate
  description and roadmap updated to match the merged enforcer boundary.

## Verification

All claims were traced to source before editing:
- `socket_connect_guard.rs:5,49` — audit-only, returns `0`.
- `file_guard.rs` / `cgroup_lock.rs` / `capable_guard.rs` — the enforcing hooks
  (deny + fail-closed).
- The opt-in conformance test (`rauhad/src/backend/linux/enforcer.rs`) matches
  the documented env-var contract (merged in #44).

Docs-only — no code change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
