### PR TITLE
Add structured runtime observability base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,12 @@ Every deny decision from the 7 LSM hooks is emitted to a BPF ring buffer (`ENFOR
 
 Ownership reading: **Syva enforces; Rauha observes.** The `rauha-evidence` crate is the normalization layer — it consumes raw enforcement records (from the eBPF backend / Syva) plus Rauha lifecycle events and projects them into one stable schema. It does **not** enforce policy. Event names are stable string constants in `rauha_evidence::event_name` (e.g. `zone.file.denied`, `zone.exec.denied`, `zone.escape.cgroup_attach`, `zone.created`, `container.exited`, `image.pulled`, `policy.loaded`, plus pipeline-health events `ringbuf.drop` / `pipeline.shed`). Output goes through pluggable sinks (file / JSON).
 
+Rauha is the telemetry source, not the collector. The daemon emits structured
+JSON to stdout/stderr and may export through OTLP; cloud tags, pod/namespace
+enrichment, Fluent Bit or sidecar wiring, cold storage, and retention policy are
+downstream concerns. Observability config is TOML only; see
+`docs/observability.md`.
+
 User-facing side (CLI in `rauha-cli/src/commands/trace.rs` + formatting in `output.rs`):
 - `rauha trace` — per-zone syscall trace
 - `rauha top` — per-zone resource usage snapshot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,6 +3508,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3516,13 +3527,17 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "chrono",
  "matchers",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3645,6 +3660,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ clap = { version = "4", features = ["derive"] }
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["chrono", "env-filter", "fmt", "json"] }
 
 # OCI
 oci-spec = "0.7"

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,98 @@
+# Rauha Observability
+
+Rauha is the telemetry source. It emits structured daemon logs and normalized
+evidence events; downstream agents or collectors own cloud tags, pod or
+namespace enrichment, Fluent Bit sidecars, S3 archival, and retention policy.
+
+## Config
+
+Rauha reads TOML only. Set `RAUHA_CONFIG` to a TOML file with an optional
+`[observability]` table:
+
+```toml
+[observability]
+format = "auto"        # auto, json, text
+level = "info"         # overridden by RUST_LOG
+environment = "unknown"
+
+[observability.sampling.keep_ratio]
+"pipeline.shed" = 0.25
+
+[observability.sampling.rate_limit_per_second]
+"ringbuf.drop" = 1
+"pipeline.shed" = 1
+
+[observability.drop]
+events = ["shim.__ping__"]
+
+[observability.sinks]
+stdout = true
+
+[observability.sinks.rotating_file]
+path = "/var/log/rauha/rauhad.jsonl"
+max_size_bytes = 104857600
+max_age_seconds = 604800
+
+[observability.otlp]
+endpoint = "http://127.0.0.1:4317"
+protocol = "grpc"
+timeout_ms = 10000
+
+[observability.otlp.headers]
+authorization = "Bearer token"
+```
+
+Environment fallbacks:
+
+- `RUST_LOG` controls the tracing filter.
+- `RAUHA_LOG_LEVEL` sets the default level when `RUST_LOG` is unset.
+- `RAUHA_ENVIRONMENT` overrides `observability.environment`.
+- `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, and
+  `OTEL_EXPORTER_OTLP_TIMEOUT` override the matching OTLP fields.
+
+## Standard Keys
+
+Daemon log lines use JSON by default unless `format = "text"` is configured or
+`format = "auto"` detects an interactive stdout. Operational records include:
+
+- `timestamp`
+- `level`
+- `message`
+- `service.name`
+- `service.version`
+- `environment`
+- `host.id`
+- `host.name`
+- `pid`
+- `request_id`
+- `correlation_id`
+- `trace.id`
+- `span.id`
+
+Evidence events reuse `rauha-evidence` names and add stable event keys such as
+`event.name`, `event.kind`, `event.outcome`, `backend.name`, `trust_level`,
+`degraded_reason`, `duration_ms`, `error.code`, and `error.kind`.
+
+## Levels
+
+- `DEBUG`: verbose implementation detail.
+- `INFO`: normal lifecycle and request progress.
+- `WARN`: recoverable or degraded behavior, including inactive network
+  filtering in rootless development.
+- `ERROR`: needs operator attention.
+- Fatal process exits should be reserved for unrecoverable startup or
+  enforcement faults.
+
+## OTLP
+
+The `otlp` cargo feature is the intended vendor-neutral export path. When the
+feature is disabled or no endpoint is configured, stdout JSON remains the
+source of truth and OTLP is a no-op.
+
+## Cost Controls
+
+Defaults drop shim health-check noise (`shim.__ping__`) and reserve event-name
+controls for noisy pipeline-health records such as `ringbuf.drop` and
+`pipeline.shed`. Userspace subscriber lag is converted into `pipeline.shed`.
+Kernel-side full-ring-buffer drops still require a BPF-side counter before
+Rauha can report every `ringbuf.drop` loss without inference.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -25,6 +25,9 @@ environment = "unknown"
 [observability.drop]
 events = ["shim.__ping__"]
 
+# NOTE: sink routing is parsed but NOT yet wired — logs always go to stdout
+# regardless of these settings. Setting stdout=false or rotating_file logs a
+# startup warning. (Tracked for a follow-up slice.)
 [observability.sinks]
 stdout = true
 
@@ -53,10 +56,11 @@ Environment fallbacks:
 ## Standard Keys
 
 Daemon log lines use JSON by default unless `format = "text"` is configured or
-`format = "auto"` detects an interactive stdout. Operational records include:
+`format = "auto"` detects an interactive stdout. `timestamp` is RFC3339 UTC with
+millisecond precision. Operational records include:
 
 - `timestamp`
-- `level`
+- `log.level`
 - `message`
 - `service.name`
 - `service.version`

--- a/rauha-cli/src/commands/trace.rs
+++ b/rauha-cli/src/commands/trace.rs
@@ -1,7 +1,8 @@
 use clap::Args;
+use serde::Serialize;
 use tokio_stream::StreamExt;
 
-use super::connect;
+use super::{connect, output::OutputMode};
 
 mod pb {
     pub mod zone {
@@ -28,11 +29,29 @@ pub struct EventsArgs {
     pub zone: Option<String>,
 }
 
-pub async fn handle_trace(args: TraceArgs) -> anyhow::Result<()> {
-    println!(
-        "Tracing zone {}... (not yet implemented)",
-        args.zone
-    );
+#[derive(Serialize)]
+struct TracePlaceholder<'a> {
+    ok: bool,
+    zone: &'a str,
+    status: &'a str,
+}
+
+pub async fn handle_trace(args: TraceArgs, out: OutputMode) -> anyhow::Result<()> {
+    match out {
+        OutputMode::Human => {
+            println!("Tracing zone {}... (not yet implemented)", args.zone);
+        }
+        OutputMode::Json => {
+            println!(
+                "{}",
+                serde_json::to_string(&TracePlaceholder {
+                    ok: false,
+                    zone: &args.zone,
+                    status: "not_implemented",
+                })?
+            );
+        }
+    }
     Ok(())
 }
 
@@ -41,10 +60,17 @@ pub async fn handle_top(_args: TopArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn handle_events(args: EventsArgs) -> anyhow::Result<()> {
+#[derive(Serialize)]
+struct StreamEvent<'a> {
+    timestamp: &'a str,
+    zone_name: &'a str,
+    event_type: &'a str,
+    event: serde_json::Value,
+}
+
+pub async fn handle_events(args: EventsArgs, out: OutputMode) -> anyhow::Result<()> {
     let channel = connect().await?;
-    let mut client =
-        pb::zone::zone_service_client::ZoneServiceClient::new(channel);
+    let mut client = pb::zone::zone_service_client::ZoneServiceClient::new(channel);
 
     let request = pb::zone::WatchEventsRequest {
         zone_name: args.zone.unwrap_or_default(),
@@ -52,19 +78,39 @@ pub async fn handle_events(args: EventsArgs) -> anyhow::Result<()> {
 
     let mut stream = client.watch_events(request).await?.into_inner();
 
-    eprintln!("streaming enforcement events (Ctrl+C to stop)...");
-    eprintln!();
+    if out == OutputMode::Human {
+        eprintln!("streaming enforcement events (Ctrl+C to stop)...");
+        eprintln!();
+    }
 
     while let Some(event) = stream.next().await {
         match event {
-            Ok(e) => {
-                println!(
-                    "{}  {}  {}",
-                    format_timestamp(&e.timestamp),
-                    e.event_type,
-                    e.message,
-                );
-            }
+            Ok(e) => match out {
+                OutputMode::Human => {
+                    println!(
+                        "{}  {}  {}",
+                        format_timestamp(&e.timestamp),
+                        e.event_type,
+                        e.message,
+                    );
+                }
+                OutputMode::Json => {
+                    let event = serde_json::from_str(&e.message).unwrap_or_else(|_| {
+                        serde_json::json!({
+                            "message": e.message,
+                        })
+                    });
+                    println!(
+                        "{}",
+                        serde_json::to_string(&StreamEvent {
+                            timestamp: &e.timestamp,
+                            zone_name: &e.zone_name,
+                            event_type: &e.event_type,
+                            event,
+                        })?
+                    );
+                }
+            },
             Err(e) => {
                 eprintln!("stream error: {e}");
                 break;

--- a/rauha-cli/src/main.rs
+++ b/rauha-cli/src/main.rs
@@ -4,7 +4,11 @@ use clap::{Parser, Subcommand};
 use commands::output::OutputMode;
 
 #[derive(Parser)]
-#[command(name = "rauha", version, about = "Agent sandbox runtime built on controlled execution zones")]
+#[command(
+    name = "rauha",
+    version,
+    about = "Agent sandbox runtime built on controlled execution zones"
+)]
 struct Cli {
     /// Output JSON instead of human-readable text
     #[arg(long, global = true)]
@@ -59,9 +63,7 @@ enum Commands {
 fn is_streaming_command(cmd: &Commands) -> bool {
     matches!(
         cmd,
-        Commands::Trace(_)
-            | Commands::Top(_)
-            | Commands::Events(_)
+        Commands::Top(_)
             | Commands::Logs(_)
             | Commands::Exec(_)
             | Commands::Attach(_)
@@ -85,9 +87,10 @@ async fn main() {
         OutputMode::Human
     };
 
-    // Reject --json for streaming/interactive commands.
+    // Reject --json for streaming/interactive commands that still lack a
+    // line-delimited machine output contract.
     if out == OutputMode::Json && is_streaming_command(&cli.command) {
-        commands::output::print_error("--json is not supported for streaming/interactive commands (trace, top, events, logs, exec, attach, setup)");
+        commands::output::print_error("--json is not supported for streaming/interactive commands (top, logs, exec, attach, setup)");
         std::process::exit(1);
     }
 
@@ -100,9 +103,9 @@ async fn main() {
         Commands::Delete(args) => commands::run::handle_delete(args, out).await,
         Commands::Image(action) => commands::image::handle(action, out).await,
         Commands::Policy { action } => commands::policy::handle(action, out).await,
-        Commands::Trace(args) => commands::trace::handle_trace(args).await,
+        Commands::Trace(args) => commands::trace::handle_trace(args, out).await,
         Commands::Top(args) => commands::trace::handle_top(args).await,
-        Commands::Events(args) => commands::trace::handle_events(args).await,
+        Commands::Events(args) => commands::trace::handle_events(args, out).await,
         Commands::Logs(args) => commands::logs::handle_logs(args).await,
         Commands::Exec(args) => commands::exec::handle_exec(args).await,
         Commands::Attach(args) => commands::exec::handle_attach(args).await,

--- a/rauha-common/src/lib.rs
+++ b/rauha-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 pub mod container;
 pub mod error;
+pub mod observability;
 pub mod sandbox;
 pub mod shim;
 pub mod zone;

--- a/rauha-common/src/observability.rs
+++ b/rauha-common/src/observability.rs
@@ -1,0 +1,253 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct ObservabilityConfig {
+    #[serde(default = "default_format")]
+    pub format: LogFormat,
+    #[serde(default = "default_level")]
+    pub level: String,
+    #[serde(default = "default_environment")]
+    pub environment: String,
+    #[serde(default)]
+    pub sampling: SamplingConfig,
+    #[serde(default)]
+    pub drop: DropConfig,
+    #[serde(default)]
+    pub sinks: SinksConfig,
+    #[serde(default)]
+    pub otlp: OtlpConfig,
+}
+
+impl Default for ObservabilityConfig {
+    fn default() -> Self {
+        Self {
+            format: default_format(),
+            level: default_level(),
+            environment: default_environment(),
+            sampling: SamplingConfig::default(),
+            drop: DropConfig::default(),
+            sinks: SinksConfig::default(),
+            otlp: OtlpConfig::default(),
+        }
+    }
+}
+
+impl ObservabilityConfig {
+    pub fn from_env_or_default() -> Result<Self, ObservabilityConfigError> {
+        let Some(path) = std::env::var_os("RAUHA_CONFIG") else {
+            return Ok(Self::from_env_overrides(Self::default()));
+        };
+        let path = PathBuf::from(path);
+        let text =
+            std::fs::read_to_string(&path).map_err(|source| ObservabilityConfigError::Read {
+                path: path.clone(),
+                source,
+            })?;
+        let file: RauhaConfigFile =
+            toml::from_str(&text).map_err(|source| ObservabilityConfigError::Parse {
+                path: path.clone(),
+                source,
+            })?;
+        Ok(Self::from_env_overrides(
+            file.observability.unwrap_or_default(),
+        ))
+    }
+
+    fn from_env_overrides(mut config: Self) -> Self {
+        if let Ok(environment) = std::env::var("RAUHA_ENVIRONMENT") {
+            config.environment = environment;
+        }
+        if let Ok(level) = std::env::var("RAUHA_LOG_LEVEL") {
+            config.level = level;
+        }
+        if let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+            config.otlp.endpoint = Some(endpoint);
+        }
+        if let Ok(protocol) = std::env::var("OTEL_EXPORTER_OTLP_PROTOCOL") {
+            config.otlp.protocol = protocol;
+        }
+        if let Ok(timeout) = std::env::var("OTEL_EXPORTER_OTLP_TIMEOUT") {
+            if let Ok(ms) = timeout.parse::<u64>() {
+                config.otlp.timeout_ms = ms;
+            }
+        }
+        config
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LogFormat {
+    Json,
+    Text,
+    Auto,
+}
+
+fn default_format() -> LogFormat {
+    LogFormat::Auto
+}
+
+fn default_level() -> String {
+    "info".into()
+}
+
+fn default_environment() -> String {
+    "unknown".into()
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct SamplingConfig {
+    #[serde(default)]
+    pub keep_ratio: BTreeMap<String, f64>,
+    #[serde(default)]
+    pub rate_limit_per_second: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct DropConfig {
+    #[serde(default = "default_drop_events")]
+    pub events: Vec<String>,
+}
+
+impl Default for DropConfig {
+    fn default() -> Self {
+        Self {
+            events: default_drop_events(),
+        }
+    }
+}
+
+fn default_drop_events() -> Vec<String> {
+    vec!["shim.__ping__".into()]
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SinksConfig {
+    #[serde(default = "default_true")]
+    pub stdout: bool,
+    pub rotating_file: Option<RotatingFileSinkConfig>,
+}
+
+impl Default for SinksConfig {
+    fn default() -> Self {
+        Self {
+            stdout: true,
+            rotating_file: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct RotatingFileSinkConfig {
+    pub path: PathBuf,
+    pub max_size_bytes: u64,
+    pub max_age_seconds: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct OtlpConfig {
+    pub endpoint: Option<String>,
+    #[serde(default = "default_otlp_protocol")]
+    pub protocol: String,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    #[serde(default = "default_otlp_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for OtlpConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: None,
+            protocol: default_otlp_protocol(),
+            headers: BTreeMap::new(),
+            timeout_ms: default_otlp_timeout_ms(),
+        }
+    }
+}
+
+impl OtlpConfig {
+    pub fn timeout(&self) -> Duration {
+        Duration::from_millis(self.timeout_ms)
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_otlp_protocol() -> String {
+    "grpc".into()
+}
+
+fn default_otlp_timeout_ms() -> u64 {
+    10_000
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RauhaConfigFile {
+    pub observability: Option<ObservabilityConfig>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ObservabilityConfigError {
+    #[error("failed to read Rauha config at {path}: {source}; hint: set RAUHA_CONFIG to a readable TOML file or unset it to use defaults")]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse Rauha config at {path}: {source}; hint: use TOML with an [observability] table")]
+    Parse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_observability_is_json_auto_low_noise() {
+        let config = ObservabilityConfig::default();
+        assert_eq!(config.format, LogFormat::Auto);
+        assert_eq!(config.environment, "unknown");
+        assert_eq!(config.drop.events, vec!["shim.__ping__"]);
+    }
+
+    #[test]
+    fn parses_observability_table() {
+        let file: RauhaConfigFile = toml::from_str(
+            r#"
+            [observability]
+            format = "text"
+            level = "debug"
+            environment = "dev"
+
+            [observability.sampling.keep_ratio]
+            "pipeline.shed" = 0.25
+
+            [observability.otlp]
+            endpoint = "http://127.0.0.1:4317"
+            timeout_ms = 500
+            "#,
+        )
+        .unwrap();
+        let config = file.observability.unwrap();
+        assert_eq!(config.format, LogFormat::Text);
+        assert_eq!(config.level, "debug");
+        assert_eq!(config.environment, "dev");
+        assert_eq!(config.otlp.timeout(), Duration::from_millis(500));
+    }
+}

--- a/rauha-evidence/src/lib.rs
+++ b/rauha-evidence/src/lib.rs
@@ -294,13 +294,13 @@ pub struct RuntimeEvent {
     pub enforcer_capabilities: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "trace.id", skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub correlation_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "parent_span.id", skip_serializing_if = "Option::is_none")]
     pub parent_span_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "span.id", skip_serializing_if = "Option::is_none")]
     pub span_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
@@ -346,6 +346,9 @@ impl RuntimeEvent {
             backend.platform = self.backend_platform.as_deref().unwrap_or(""),
             backend.enforcement_mode = self.backend_enforcement_mode.map(EnforcementMode::as_str).unwrap_or(""),
             enforcer.backend = self.enforcer_backend.as_deref().unwrap_or(""),
+            trace.id = self.trace_id.as_deref().unwrap_or(""),
+            span.id = self.span_id.as_deref().unwrap_or(""),
+            parent_span.id = self.parent_span_id.as_deref().unwrap_or(""),
             correlation_id = self.correlation_id.as_deref().unwrap_or(""),
             request_id = self.request_id.as_deref().unwrap_or(""),
             trust_level = self.trust_level.map(TrustLevel::as_str).unwrap_or(""),
@@ -370,6 +373,9 @@ impl RuntimeEvent {
             backend.platform = self.backend_platform.as_deref().unwrap_or(""),
             backend.enforcement_mode = self.backend_enforcement_mode.map(EnforcementMode::as_str).unwrap_or(""),
             enforcer.backend = self.enforcer_backend.as_deref().unwrap_or(""),
+            trace.id = self.trace_id.as_deref().unwrap_or(""),
+            span.id = self.span_id.as_deref().unwrap_or(""),
+            parent_span.id = self.parent_span_id.as_deref().unwrap_or(""),
             correlation_id = self.correlation_id.as_deref().unwrap_or(""),
             request_id = self.request_id.as_deref().unwrap_or(""),
             trust_level = self.trust_level.map(TrustLevel::as_str).unwrap_or(""),
@@ -394,6 +400,9 @@ impl RuntimeEvent {
             backend.platform = self.backend_platform.as_deref().unwrap_or(""),
             backend.enforcement_mode = self.backend_enforcement_mode.map(EnforcementMode::as_str).unwrap_or(""),
             enforcer.backend = self.enforcer_backend.as_deref().unwrap_or(""),
+            trace.id = self.trace_id.as_deref().unwrap_or(""),
+            span.id = self.span_id.as_deref().unwrap_or(""),
+            parent_span.id = self.parent_span_id.as_deref().unwrap_or(""),
             correlation_id = self.correlation_id.as_deref().unwrap_or(""),
             request_id = self.request_id.as_deref().unwrap_or(""),
             trust_level = self.trust_level.map(TrustLevel::as_str).unwrap_or(""),
@@ -418,6 +427,9 @@ impl RuntimeEvent {
             backend.platform = self.backend_platform.as_deref().unwrap_or(""),
             backend.enforcement_mode = self.backend_enforcement_mode.map(EnforcementMode::as_str).unwrap_or(""),
             enforcer.backend = self.enforcer_backend.as_deref().unwrap_or(""),
+            trace.id = self.trace_id.as_deref().unwrap_or(""),
+            span.id = self.span_id.as_deref().unwrap_or(""),
+            parent_span.id = self.parent_span_id.as_deref().unwrap_or(""),
             correlation_id = self.correlation_id.as_deref().unwrap_or(""),
             request_id = self.request_id.as_deref().unwrap_or(""),
             trust_level = self.trust_level.map(TrustLevel::as_str).unwrap_or(""),
@@ -553,6 +565,21 @@ impl RuntimeEventBuilder {
         self
     }
 
+    pub fn trace_id(mut self, value: impl Into<String>) -> Self {
+        self.event.trace_id = Some(bound_string(&value.into()));
+        self
+    }
+
+    pub fn span_id(mut self, value: impl Into<String>) -> Self {
+        self.event.span_id = Some(bound_string(&value.into()));
+        self
+    }
+
+    pub fn parent_span_id(mut self, value: impl Into<String>) -> Self {
+        self.event.parent_span_id = Some(bound_string(&value.into()));
+        self
+    }
+
     pub fn duration_ms(mut self, value: u64) -> Self {
         self.event.duration_ms = Some(value);
         self
@@ -669,7 +696,7 @@ pub struct FalseEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource: Option<String>,
     pub backend: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "trace.id", skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
     pub what_failed: String,
     pub why_it_matters: String,

--- a/rauhad/Cargo.toml
+++ b/rauhad/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+otlp = []
+
 [dependencies]
 rauha-common = { path = "../rauha-common" }
 rauha-enforcer-api = { path = "../rauha-enforcer-api" }

--- a/rauhad/src/logging.rs
+++ b/rauhad/src/logging.rs
@@ -1,0 +1,254 @@
+//! Daemon logging setup.
+//!
+//! Rauha is the telemetry source: it emits one structured JSON object per log
+//! line to stdout, with standardized resource keys (`service.name`, `host.id`,
+//! …) present on EVERY line as top-level fields — independent of which tokio
+//! task produced the event. A `tracing` span guard cannot do this (it does not
+//! cross task boundaries and nests its fields under `span`), so we format events
+//! ourselves in a small `Layer` and inject the constant resource fields plus any
+//! active span scope (request/correlation/trace/span ids) flat into the object.
+
+use std::io::Write;
+
+use rauha_common::observability::{LogFormat, ObservabilityConfig};
+use serde_json::{json, Map, Value};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::fmt::time::ChronoUtc;
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::EnvFilter;
+
+/// Initialize the global tracing subscriber from observability config.
+pub fn init(config: &ObservabilityConfig) -> anyhow::Result<()> {
+    // RUST_LOG wins; otherwise default to the configured level for rauhad AND
+    // the evidence target (evidence events are emitted on the `rauha_evidence`
+    // target — without this they would be filtered out by default).
+    let lvl = &config.level;
+    let default_directives = format!("rauhad={lvl},rauha_evidence={lvl},rauha_shim={lvl}");
+    let filter =
+        EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new(&default_directives))?;
+
+    let format = match config.format {
+        LogFormat::Json => LogFormat::Json,
+        LogFormat::Text => LogFormat::Text,
+        LogFormat::Auto if stdout_is_tty() => LogFormat::Text,
+        LogFormat::Auto => LogFormat::Json,
+    };
+
+    match format {
+        LogFormat::Text => {
+            // Human dev output — unchanged from the original fmt subscriber.
+            tracing_subscriber::fmt()
+                .with_timer(ChronoUtc::rfc_3339())
+                .with_env_filter(filter)
+                .with_writer(std::io::stdout)
+                .init();
+        }
+        _ => {
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(JsonLogLayer::new(resource_fields(config)))
+                .init();
+        }
+    }
+    Ok(())
+}
+
+/// Constant resource attributes attached to every log line as top-level keys.
+fn resource_fields(config: &ObservabilityConfig) -> Vec<(&'static str, Value)> {
+    vec![
+        ("service.name", json!("rauhad")),
+        ("service.version", json!(env!("CARGO_PKG_VERSION"))),
+        ("environment", json!(config.environment)),
+        ("host.id", json!(host_id())),
+        ("host.name", json!(host_name())),
+        ("pid", json!(std::process::id())),
+    ]
+}
+
+/// A `tracing` layer that writes one flat JSON object per event to stdout.
+struct JsonLogLayer {
+    resource: Vec<(&'static str, Value)>,
+}
+
+impl JsonLogLayer {
+    fn new(resource: Vec<(&'static str, Value)>) -> Self {
+        Self { resource }
+    }
+}
+
+/// Structured span fields, captured at span creation and merged into every
+/// event emitted within that span's scope.
+struct SpanFields(Map<String, Value>);
+
+impl<S> Layer<S> for JsonLogLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::Id,
+        ctx: Context<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id) {
+            let mut fields = Map::new();
+            attrs.record(&mut JsonVisitor::new(&mut fields));
+            span.extensions_mut().insert(SpanFields(fields));
+        }
+    }
+
+    fn on_record(&self, id: &tracing::Id, values: &tracing::span::Record<'_>, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut ext = span.extensions_mut();
+            if let Some(SpanFields(fields)) = ext.get_mut::<SpanFields>() {
+                values.record(&mut JsonVisitor::new(fields));
+            }
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let mut map = Map::new();
+
+        let meta = event.metadata();
+        map.insert("timestamp".into(), json!(now_rfc3339()));
+        map.insert("level".into(), json!(meta.level().as_str()));
+        map.insert("target".into(), json!(meta.target()));
+
+        // Constant resource attributes (top-level, every line).
+        for (key, value) in &self.resource {
+            map.insert((*key).to_string(), value.clone());
+        }
+
+        // Active span scope (root → current): request/correlation/trace/span ids.
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope.from_root() {
+                if let Some(SpanFields(fields)) = span.extensions().get::<SpanFields>() {
+                    for (key, value) in fields {
+                        map.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+        }
+
+        // Event's own fields. An empty-string field does not override a
+        // non-empty resource/span value already present — this lets evidence
+        // events (which emit empty `correlation_id`/`trace.id` when unset)
+        // inherit the active request's ids from span scope.
+        event.record(&mut JsonVisitor::with_skip_empty(&mut map));
+
+        if let Ok(line) = serde_json::to_string(&Value::Object(map)) {
+            let mut out = std::io::stdout().lock();
+            let _ = writeln!(out, "{line}");
+        }
+    }
+}
+
+struct JsonVisitor<'a> {
+    map: &'a mut Map<String, Value>,
+    skip_empty: bool,
+}
+
+impl<'a> JsonVisitor<'a> {
+    fn new(map: &'a mut Map<String, Value>) -> Self {
+        Self {
+            map,
+            skip_empty: false,
+        }
+    }
+
+    fn with_skip_empty(map: &'a mut Map<String, Value>) -> Self {
+        Self {
+            map,
+            skip_empty: true,
+        }
+    }
+
+    fn put(&mut self, key: &str, value: Value) {
+        if self.skip_empty {
+            if let Value::String(s) = &value {
+                if s.is_empty() && self.map.contains_key(key) {
+                    return;
+                }
+            }
+        }
+        self.map.insert(key.to_string(), value);
+    }
+}
+
+impl Visit for JsonVisitor<'_> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.put(field.name(), Value::String(value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.put(field.name(), Value::Bool(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.put(field.name(), Value::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.put(field.name(), Value::from(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.put(field.name(), Value::from(value));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        // The message format string is recorded here under the "message" field;
+        // Debug of fmt::Arguments / DisplayValue yields the plain string.
+        self.put(field.name(), Value::String(format!("{value:?}")));
+    }
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)
+}
+
+fn stdout_is_tty() -> bool {
+    unsafe { libc::isatty(libc::STDOUT_FILENO) == 1 }
+}
+
+fn host_id() -> String {
+    std::fs::read_to_string("/etc/machine-id")
+        .or_else(|_| std::fs::read_to_string("/var/lib/dbus/machine-id"))
+        .map(|s| s.trim().to_string())
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(host_name)
+}
+
+fn host_name() -> String {
+    std::env::var("HOSTNAME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_event_field_does_not_override_existing() {
+        let mut map = Map::new();
+        map.insert("correlation_id".into(), json!("abc"));
+        let mut v = JsonVisitor::with_skip_empty(&mut map);
+        v.put("correlation_id", json!(""));
+        assert_eq!(map.get("correlation_id"), Some(&json!("abc")));
+    }
+
+    #[test]
+    fn non_empty_event_field_overrides() {
+        let mut map = Map::new();
+        map.insert("correlation_id".into(), json!("abc"));
+        let mut v = JsonVisitor::with_skip_empty(&mut map);
+        v.put("correlation_id", json!("xyz"));
+        assert_eq!(map.get("correlation_id"), Some(&json!("xyz")));
+    }
+}

--- a/rauhad/src/logging.rs
+++ b/rauhad/src/logging.rs
@@ -53,6 +53,17 @@ pub fn init(config: &ObservabilityConfig) -> anyhow::Result<()> {
                 .init();
         }
     }
+
+    // Sink routing beyond stdout is parsed and documented but not yet wired.
+    // Be honest about it at startup rather than silently ignoring the config.
+    if !config.sinks.stdout || config.sinks.rotating_file.is_some() {
+        tracing::warn!(
+            stdout = config.sinks.stdout,
+            rotating_file = config.sinks.rotating_file.is_some(),
+            "observability sink routing is not yet implemented; logs always go to \
+             stdout regardless of [observability.sinks] (stdout=false / rotating_file ignored)"
+        );
+    }
     Ok(())
 }
 
@@ -114,7 +125,7 @@ where
 
         let meta = event.metadata();
         map.insert("timestamp".into(), json!(now_rfc3339()));
-        map.insert("level".into(), json!(meta.level().as_str()));
+        map.insert("log.level".into(), json!(meta.level().as_str()));
         map.insert("target".into(), json!(meta.target()));
 
         // Constant resource attributes (top-level, every line).
@@ -207,7 +218,8 @@ impl Visit for JsonVisitor<'_> {
 }
 
 fn now_rfc3339() -> String {
-    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)
+    // RFC3339 UTC, millisecond precision, per the observability schema.
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
 fn stdout_is_tty() -> bool {

--- a/rauhad/src/main.rs
+++ b/rauhad/src/main.rs
@@ -9,10 +9,12 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use rauha_common::observability::{LogFormat, ObservabilityConfig};
 use rauha_evidence::{
     event_name, EnforcementMode, EventKind, EventOutcome, RuntimeEventBuilder, Severity, TrustLevel,
 };
 use tonic::transport::Server;
+use tracing_subscriber::fmt::time::ChronoUtc;
 use tracing_subscriber::EnvFilter;
 
 use server::pb::container::container_service_server::ContainerServiceServer;
@@ -28,9 +30,19 @@ const DEFAULT_ROOT: &str = if cfg!(target_os = "macos") {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive("rauhad=info".parse()?))
-        .init();
+    let observability = ObservabilityConfig::from_env_or_default()?;
+    init_tracing(&observability)?;
+    install_panic_hook();
+    let _process_span = tracing::info_span!(
+        "rauhad",
+        service.name = "rauhad",
+        service.version = env!("CARGO_PKG_VERSION"),
+        environment = %observability.environment,
+        host.id = %host_id(),
+        host.name = %host_name(),
+        pid = std::process::id(),
+    )
+    .entered();
 
     let root = std::env::var("RAUHA_ROOT").unwrap_or_else(|_| DEFAULT_ROOT.into());
     let root_path = PathBuf::from(&root);
@@ -192,4 +204,77 @@ fn cleanup_network() {
     tracing::info!("cleaning up network state");
     #[cfg(target_os = "linux")]
     backend::linux::cleanup_network();
+}
+
+fn init_tracing(config: &ObservabilityConfig) -> anyhow::Result<()> {
+    let filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(format!("rauhad={}", config.level)))?;
+    let format = match config.format {
+        LogFormat::Json => LogFormat::Json,
+        LogFormat::Text => LogFormat::Text,
+        LogFormat::Auto if stdout_is_tty() => LogFormat::Text,
+        LogFormat::Auto => LogFormat::Json,
+    };
+
+    match format {
+        LogFormat::Json | LogFormat::Auto => tracing_subscriber::fmt()
+            .json()
+            .flatten_event(true)
+            .with_current_span(true)
+            .with_timer(ChronoUtc::rfc_3339())
+            .with_env_filter(filter)
+            .with_writer(std::io::stdout)
+            .init(),
+        LogFormat::Text => tracing_subscriber::fmt()
+            .with_timer(ChronoUtc::rfc_3339())
+            .with_env_filter(filter)
+            .with_writer(std::io::stdout)
+            .init(),
+    }
+    Ok(())
+}
+
+fn install_panic_hook() {
+    std::panic::set_hook(Box::new(|info| {
+        let location = info
+            .location()
+            .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+            .unwrap_or_else(|| "unknown".into());
+        let payload = info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| info.payload().downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "panic payload is not a string".into());
+        let backtrace = std::backtrace::Backtrace::force_capture().to_string();
+
+        tracing::error!(
+            event.name = "process.panic",
+            error.kind = "panic",
+            error.message = %payload,
+            location = %location,
+            backtrace = %backtrace,
+            "process.panic"
+        );
+    }));
+}
+
+fn stdout_is_tty() -> bool {
+    unsafe { libc::isatty(libc::STDOUT_FILENO) == 1 }
+}
+
+fn host_id() -> String {
+    std::fs::read_to_string("/etc/machine-id")
+        .or_else(|_| std::fs::read_to_string("/var/lib/dbus/machine-id"))
+        .map(|s| s.trim().to_string())
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(host_name)
+}
+
+fn host_name() -> String {
+    std::env::var("HOSTNAME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into())
 }

--- a/rauhad/src/main.rs
+++ b/rauhad/src/main.rs
@@ -1,4 +1,5 @@
 mod backend;
+mod logging;
 mod logs;
 mod metadata;
 mod network;
@@ -9,13 +10,11 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use rauha_common::observability::{LogFormat, ObservabilityConfig};
+use rauha_common::observability::ObservabilityConfig;
 use rauha_evidence::{
     event_name, EnforcementMode, EventKind, EventOutcome, RuntimeEventBuilder, Severity, TrustLevel,
 };
 use tonic::transport::Server;
-use tracing_subscriber::fmt::time::ChronoUtc;
-use tracing_subscriber::EnvFilter;
 
 use server::pb::container::container_service_server::ContainerServiceServer;
 use server::pb::image::image_service_server::ImageServiceServer;
@@ -31,18 +30,8 @@ const DEFAULT_ROOT: &str = if cfg!(target_os = "macos") {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let observability = ObservabilityConfig::from_env_or_default()?;
-    init_tracing(&observability)?;
+    logging::init(&observability)?;
     install_panic_hook();
-    let _process_span = tracing::info_span!(
-        "rauhad",
-        service.name = "rauhad",
-        service.version = env!("CARGO_PKG_VERSION"),
-        environment = %observability.environment,
-        host.id = %host_id(),
-        host.name = %host_name(),
-        pid = std::process::id(),
-    )
-    .entered();
 
     let root = std::env::var("RAUHA_ROOT").unwrap_or_else(|_| DEFAULT_ROOT.into());
     let root_path = PathBuf::from(&root);
@@ -206,34 +195,6 @@ fn cleanup_network() {
     backend::linux::cleanup_network();
 }
 
-fn init_tracing(config: &ObservabilityConfig) -> anyhow::Result<()> {
-    let filter = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new(format!("rauhad={}", config.level)))?;
-    let format = match config.format {
-        LogFormat::Json => LogFormat::Json,
-        LogFormat::Text => LogFormat::Text,
-        LogFormat::Auto if stdout_is_tty() => LogFormat::Text,
-        LogFormat::Auto => LogFormat::Json,
-    };
-
-    match format {
-        LogFormat::Json | LogFormat::Auto => tracing_subscriber::fmt()
-            .json()
-            .flatten_event(true)
-            .with_current_span(true)
-            .with_timer(ChronoUtc::rfc_3339())
-            .with_env_filter(filter)
-            .with_writer(std::io::stdout)
-            .init(),
-        LogFormat::Text => tracing_subscriber::fmt()
-            .with_timer(ChronoUtc::rfc_3339())
-            .with_env_filter(filter)
-            .with_writer(std::io::stdout)
-            .init(),
-    }
-    Ok(())
-}
-
 fn install_panic_hook() {
     std::panic::set_hook(Box::new(|info| {
         let location = info
@@ -257,24 +218,4 @@ fn install_panic_hook() {
             "process.panic"
         );
     }));
-}
-
-fn stdout_is_tty() -> bool {
-    unsafe { libc::isatty(libc::STDOUT_FILENO) == 1 }
-}
-
-fn host_id() -> String {
-    std::fs::read_to_string("/etc/machine-id")
-        .or_else(|_| std::fs::read_to_string("/var/lib/dbus/machine-id"))
-        .map(|s| s.trim().to_string())
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(host_name)
-}
-
-fn host_name() -> String {
-    std::env::var("HOSTNAME")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".into())
 }

--- a/rauhad/src/server.rs
+++ b/rauhad/src/server.rs
@@ -60,6 +60,50 @@ use pb::image::image_service_server::ImageService;
 use pb::sandbox::sandbox_service_server::SandboxService;
 use pb::zone::zone_service_server::ZoneService;
 
+fn rpc_span<T>(
+    request: &Request<T>,
+    rpc_service: &'static str,
+    rpc_method: &'static str,
+) -> tracing::Span {
+    let request_id = metadata_value(request, "x-request-id").unwrap_or_else(new_request_id);
+    let correlation_id =
+        metadata_value(request, "x-correlation-id").unwrap_or_else(|| request_id.clone());
+    let trace_id = request_id.replace('-', "");
+    let span_id = trace_id
+        .get(..16)
+        .map(str::to_string)
+        .unwrap_or_else(|| trace_id.clone());
+
+    tracing::info_span!(
+        "grpc.request",
+        rpc.service = rpc_service,
+        rpc.method = rpc_method,
+        request_id = %request_id,
+        correlation_id = %correlation_id,
+        trace.id = %trace_id,
+        span.id = %span_id,
+    )
+}
+
+fn emit_rpc_start<T>(request: &Request<T>, rpc_service: &'static str, rpc_method: &'static str) {
+    let span = rpc_span(request, rpc_service, rpc_method);
+    tracing::info!(parent: &span, event.name = "grpc.request.started", "grpc request started");
+}
+
+fn metadata_value<T>(request: &Request<T>, key: &str) -> Option<String> {
+    request
+        .metadata()
+        .get(key)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn new_request_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
 // --- Zone Service ---
 
 pub struct ZoneServiceImpl {
@@ -93,6 +137,7 @@ impl ZoneService for ZoneServiceImpl {
         &self,
         request: Request<pb::zone::CreateZoneRequest>,
     ) -> Result<Response<pb::zone::CreateZoneResponse>, Status> {
+        emit_rpc_start(&request, "rauha.zone.v1.ZoneService", "CreateZone");
         let req = request.into_inner();
 
         // Zone type from gRPC request field.
@@ -140,6 +185,7 @@ impl ZoneService for ZoneServiceImpl {
         &self,
         request: Request<pb::zone::DeleteZoneRequest>,
     ) -> Result<Response<pb::zone::DeleteZoneResponse>, Status> {
+        emit_rpc_start(&request, "rauha.zone.v1.ZoneService", "DeleteZone");
         let req = request.into_inner();
         self.registry
             .delete_zone(&req.name, req.force)
@@ -152,6 +198,7 @@ impl ZoneService for ZoneServiceImpl {
         &self,
         request: Request<pb::zone::GetZoneRequest>,
     ) -> Result<Response<pb::zone::GetZoneResponse>, Status> {
+        emit_rpc_start(&request, "rauha.zone.v1.ZoneService", "GetZone");
         let req = request.into_inner();
         let zone = self.registry.get_zone(&req.name).await.map_err(to_status)?;
 
@@ -174,8 +221,9 @@ impl ZoneService for ZoneServiceImpl {
 
     async fn list_zones(
         &self,
-        _request: Request<pb::zone::ListZonesRequest>,
+        request: Request<pb::zone::ListZonesRequest>,
     ) -> Result<Response<pb::zone::ListZonesResponse>, Status> {
+        emit_rpc_start(&request, "rauha.zone.v1.ZoneService", "ListZones");
         let zones = self.registry.list_zones().map_err(to_status)?;
 
         let zone_infos = zones

--- a/rauhad/src/server.rs
+++ b/rauhad/src/server.rs
@@ -1204,7 +1204,6 @@ fn sandbox_event_builder(
 ) -> RuntimeEventBuilder {
     RuntimeEventBuilder::new(name, EventKind::Execution, outcome)
         .task_id(task_id)
-        .correlation_id(task_id)
         .zone_name(zone_name)
         .zone_id(zone_id)
         .backend(
@@ -1673,7 +1672,6 @@ fn emit_enforcement_capture_state(
             )
             .level(Severity::Warn)
             .task_id(task_id)
-            .correlation_id(task_id)
             .zone_name(zone_name)
             .zone_id(zone_id)
             .backend(
@@ -1693,7 +1691,6 @@ fn emit_enforcement_capture_state(
             )
             .level(Severity::Warn)
             .task_id(task_id)
-            .correlation_id(task_id)
             .zone_name(zone_name)
             .zone_id(zone_id)
             .backend(
@@ -1713,7 +1710,6 @@ fn emit_enforcement_capture_state(
             )
             .level(Severity::Warn)
             .task_id(task_id)
-            .correlation_id(task_id)
             .zone_name(zone_name)
             .zone_id(zone_id)
             .backend(
@@ -1894,160 +1890,168 @@ impl SandboxService for SandboxServiceImpl {
         &self,
         request: Request<pb::sandbox::RunSandboxRequest>,
     ) -> Result<Response<pb::sandbox::SandboxResult>, Status> {
-        let req = request.into_inner();
-        let task_id = format!("task-{}", uuid::Uuid::new_v4());
-        RuntimeEventBuilder::new(
-            event_name::SANDBOX_RUN_STARTED,
-            EventKind::Execution,
-            EventOutcome::Started,
-        )
-        .task_id(&task_id)
-        .correlation_id(&task_id)
-        .image_ref(&req.image)
-        .command_hash(command_hash(&req.command))
-        .repo_path_safe(&req.repo_path)
-        .backend(
-            self.registry.backend_name(),
-            self.registry.backend_platform(),
-            self.registry.enforcement_mode(),
-        )
-        .trust_level(TrustLevel::BestEffort)
-        .degraded_reason("enforcement_capture_status_reported_separately")
-        .emit();
-
-        if let Err(status) = validate_sandbox_request(&req) {
+        // Correlate the primary sandbox path with its gRPC request like the
+        // zone handlers: open a request span so this handler's logs and all the
+        // sandbox evidence events (emitted inline below) share one trace.id /
+        // span.id / correlation_id. task_id stays a distinct field.
+        let span = rpc_span(&request, "rauha.sandbox.v1.SandboxService", "RunSandbox");
+        async move {
+            tracing::info!(event.name = "grpc.request.started", "grpc request started");
+            let req = request.into_inner();
+            let task_id = format!("task-{}", uuid::Uuid::new_v4());
             RuntimeEventBuilder::new(
-                event_name::SANDBOX_RUN_FAILED,
+                event_name::SANDBOX_RUN_STARTED,
                 EventKind::Execution,
-                EventOutcome::Failed,
+                EventOutcome::Started,
             )
-            .level(Severity::Warn)
             .task_id(&task_id)
-            .correlation_id(&task_id)
             .image_ref(&req.image)
             .command_hash(command_hash(&req.command))
+            .repo_path_safe(&req.repo_path)
             .backend(
                 self.registry.backend_name(),
                 self.registry.backend_platform(),
                 self.registry.enforcement_mode(),
             )
-            .error(
-                "sandbox_request_invalid",
-                format!("{:?}", status.code()),
-                status.message().to_string(),
-            )
-            .trust_level(TrustLevel::Complete)
+            .trust_level(TrustLevel::BestEffort)
+            .degraded_reason("enforcement_capture_status_reported_separately")
             .emit();
-            return Err(status);
-        }
 
-        // Resolve the zone. An empty name allocates a temporary zone that we own
-        // and (by default) delete afterwards; a named zone must already exist
-        // and is left intact.
-        let (zone_name, zone_id, temp_zone) = if req.name.trim().is_empty() {
-            let name = format!(
-                "sandbox-{}",
-                &uuid::Uuid::new_v4().simple().to_string()[..12]
-            );
-            let zone = self
-                .registry
-                .create_zone(
-                    &name,
-                    rauha_common::zone::ZoneType::NonGlobal,
-                    rauha_common::zone::ZonePolicy::default(),
-                )
-                .await
-                .map_err(to_status)?;
-            sandbox_event_builder(
-                &self.registry,
-                event_name::SANDBOX_ZONE_ALLOCATED,
-                EventOutcome::Succeeded,
-                &task_id,
-                &zone.name,
-                &zone.id.to_string(),
-            )
-            .trust_level(TrustLevel::Complete)
-            .emit();
-            (zone.name, zone.id.to_string(), true)
-        } else {
-            let zone = self.registry.get_zone(&req.name).await.map_err(to_status)?;
-            (zone.name, zone.id.to_string(), false)
-        };
-        let mut zone_cleanup = (temp_zone && !req.keep_zone)
-            .then(|| ZoneCleanupGuard::new(self.registry.clone(), zone_name.clone()));
-
-        let outcome = self
-            .execute_task(&task_id, &zone_name, &zone_id, &req)
-            .await;
-
-        // Tear down the temporary zone unless the caller asked to keep it.
-        if temp_zone && !req.keep_zone {
-            if let Err(e) = self.registry.delete_zone(&zone_name, true).await {
-                tracing::warn!(zone = zone_name, %e, "failed to delete temporary sandbox zone");
-                sandbox_event_builder(
-                    &self.registry,
-                    event_name::SANDBOX_CLEANUP_PARTIAL,
-                    EventOutcome::Degraded,
-                    &task_id,
-                    &zone_name,
-                    &zone_id,
+            if let Err(status) = validate_sandbox_request(&req) {
+                RuntimeEventBuilder::new(
+                    event_name::SANDBOX_RUN_FAILED,
+                    EventKind::Execution,
+                    EventOutcome::Failed,
                 )
                 .level(Severity::Warn)
-                .error("zone_cleanup_failed", "cleanup", e.to_string())
-                .trust_level(TrustLevel::Partial)
-                .degraded_reason("temporary_zone_delete_failed")
+                .task_id(&task_id)
+                .image_ref(&req.image)
+                .command_hash(command_hash(&req.command))
+                .backend(
+                    self.registry.backend_name(),
+                    self.registry.backend_platform(),
+                    self.registry.enforcement_mode(),
+                )
+                .error(
+                    "sandbox_request_invalid",
+                    format!("{:?}", status.code()),
+                    status.message().to_string(),
+                )
+                .trust_level(TrustLevel::Complete)
                 .emit();
+                return Err(status);
             }
-            if let Some(cleanup) = &mut zone_cleanup {
-                cleanup.disarm();
+
+            // Resolve the zone. An empty name allocates a temporary zone that we own
+            // and (by default) delete afterwards; a named zone must already exist
+            // and is left intact.
+            let (zone_name, zone_id, temp_zone) = if req.name.trim().is_empty() {
+                let name = format!(
+                    "sandbox-{}",
+                    &uuid::Uuid::new_v4().simple().to_string()[..12]
+                );
+                let zone = self
+                    .registry
+                    .create_zone(
+                        &name,
+                        rauha_common::zone::ZoneType::NonGlobal,
+                        rauha_common::zone::ZonePolicy::default(),
+                    )
+                    .await
+                    .map_err(to_status)?;
+                sandbox_event_builder(
+                    &self.registry,
+                    event_name::SANDBOX_ZONE_ALLOCATED,
+                    EventOutcome::Succeeded,
+                    &task_id,
+                    &zone.name,
+                    &zone.id.to_string(),
+                )
+                .trust_level(TrustLevel::Complete)
+                .emit();
+                (zone.name, zone.id.to_string(), true)
+            } else {
+                let zone = self.registry.get_zone(&req.name).await.map_err(to_status)?;
+                (zone.name, zone.id.to_string(), false)
+            };
+            let mut zone_cleanup = (temp_zone && !req.keep_zone)
+                .then(|| ZoneCleanupGuard::new(self.registry.clone(), zone_name.clone()));
+
+            let outcome = self
+                .execute_task(&task_id, &zone_name, &zone_id, &req)
+                .await;
+
+            // Tear down the temporary zone unless the caller asked to keep it.
+            if temp_zone && !req.keep_zone {
+                if let Err(e) = self.registry.delete_zone(&zone_name, true).await {
+                    tracing::warn!(zone = zone_name, %e, "failed to delete temporary sandbox zone");
+                    sandbox_event_builder(
+                        &self.registry,
+                        event_name::SANDBOX_CLEANUP_PARTIAL,
+                        EventOutcome::Degraded,
+                        &task_id,
+                        &zone_name,
+                        &zone_id,
+                    )
+                    .level(Severity::Warn)
+                    .error("zone_cleanup_failed", "cleanup", e.to_string())
+                    .trust_level(TrustLevel::Partial)
+                    .degraded_reason("temporary_zone_delete_failed")
+                    .emit();
+                }
+                if let Some(cleanup) = &mut zone_cleanup {
+                    cleanup.disarm();
+                }
             }
+
+            let exec = outcome.unwrap_or_else(|message| {
+                SandboxExecResult::runtime_error(&task_id, &zone_id, req.command.clone(), message)
+            });
+            let run_event = match exec.status {
+                SandboxStatus::Succeeded => (
+                    event_name::SANDBOX_RUN_SUCCEEDED,
+                    EventOutcome::Succeeded,
+                    Severity::Info,
+                ),
+                SandboxStatus::Failed | SandboxStatus::RuntimeError => (
+                    event_name::SANDBOX_RUN_FAILED,
+                    EventOutcome::Failed,
+                    Severity::Warn,
+                ),
+                SandboxStatus::TimedOut => (
+                    event_name::SANDBOX_RUN_FAILED,
+                    EventOutcome::TimedOut,
+                    Severity::Warn,
+                ),
+            };
+            sandbox_event_builder(
+                &self.registry,
+                run_event.0,
+                run_event.1,
+                &task_id,
+                &zone_name,
+                &zone_id,
+            )
+            .level(run_event.2)
+            .duration_ms(exec.duration_ms)
+            .field(
+                "status",
+                FieldValue::String(sandbox_status_str(exec.status).to_string()),
+            )
+            .field(
+                "exit_code",
+                exec.exit_code
+                    .map(|code| FieldValue::I64(code as i64))
+                    .unwrap_or_else(|| FieldValue::String("none".into())),
+            )
+            .trust_level(TrustLevel::BestEffort)
+            .degraded_reason("enforcement_events_are_best_effort")
+            .emit();
+
+            Ok(Response::new(to_proto_result(exec)))
         }
-
-        let exec = outcome.unwrap_or_else(|message| {
-            SandboxExecResult::runtime_error(&task_id, &zone_id, req.command.clone(), message)
-        });
-        let run_event = match exec.status {
-            SandboxStatus::Succeeded => (
-                event_name::SANDBOX_RUN_SUCCEEDED,
-                EventOutcome::Succeeded,
-                Severity::Info,
-            ),
-            SandboxStatus::Failed | SandboxStatus::RuntimeError => (
-                event_name::SANDBOX_RUN_FAILED,
-                EventOutcome::Failed,
-                Severity::Warn,
-            ),
-            SandboxStatus::TimedOut => (
-                event_name::SANDBOX_RUN_FAILED,
-                EventOutcome::TimedOut,
-                Severity::Warn,
-            ),
-        };
-        sandbox_event_builder(
-            &self.registry,
-            run_event.0,
-            run_event.1,
-            &task_id,
-            &zone_name,
-            &zone_id,
-        )
-        .level(run_event.2)
-        .duration_ms(exec.duration_ms)
-        .field(
-            "status",
-            FieldValue::String(sandbox_status_str(exec.status).to_string()),
-        )
-        .field(
-            "exit_code",
-            exec.exit_code
-                .map(|code| FieldValue::I64(code as i64))
-                .unwrap_or_else(|| FieldValue::String("none".into())),
-        )
-        .trust_level(TrustLevel::BestEffort)
-        .degraded_reason("enforcement_events_are_best_effort")
-        .emit();
-
-        Ok(Response::new(to_proto_result(exec)))
+        .instrument(span)
+        .await
     }
 }
 

--- a/rauhad/src/server.rs
+++ b/rauhad/src/server.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
+use tracing::Instrument;
 
 use rauha_common::error::RauhaError;
 use rauha_evidence::{
@@ -85,11 +86,6 @@ fn rpc_span<T>(
     )
 }
 
-fn emit_rpc_start<T>(request: &Request<T>, rpc_service: &'static str, rpc_method: &'static str) {
-    let span = rpc_span(request, rpc_service, rpc_method);
-    tracing::info!(parent: &span, event.name = "grpc.request.started", "grpc request started");
-}
-
 fn metadata_value<T>(request: &Request<T>, key: &str) -> Option<String> {
     request
         .metadata()
@@ -137,117 +133,137 @@ impl ZoneService for ZoneServiceImpl {
         &self,
         request: Request<pb::zone::CreateZoneRequest>,
     ) -> Result<Response<pb::zone::CreateZoneResponse>, Status> {
-        emit_rpc_start(&request, "rauha.zone.v1.ZoneService", "CreateZone");
-        let req = request.into_inner();
+        let span = rpc_span(&request, "rauha.zone.v1.ZoneService", "CreateZone");
+        async move {
+            tracing::info!(event.name = "grpc.request.started", "grpc request started");
+            let req = request.into_inner();
 
-        // Zone type from gRPC request field.
-        let zone_type = match req.zone_type.as_str() {
-            "privileged" => rauha_common::zone::ZoneType::Privileged,
-            "global" => rauha_common::zone::ZoneType::Global,
-            _ => rauha_common::zone::ZoneType::NonGlobal,
-        };
+            // Zone type from gRPC request field.
+            let zone_type = match req.zone_type.as_str() {
+                "privileged" => rauha_common::zone::ZoneType::Privileged,
+                "global" => rauha_common::zone::ZoneType::Global,
+                _ => rauha_common::zone::ZoneType::NonGlobal,
+            };
 
-        // Reject oversized policy TOML to prevent memory exhaustion during parsing.
-        const MAX_POLICY_SIZE: usize = 64 * 1024;
-        if req.policy_toml.len() > MAX_POLICY_SIZE {
-            return Err(Status::invalid_argument(format!(
-                "policy_toml exceeds maximum size of {MAX_POLICY_SIZE} bytes"
-            )));
+            // Reject oversized policy TOML to prevent memory exhaustion during parsing.
+            const MAX_POLICY_SIZE: usize = 64 * 1024;
+            if req.policy_toml.len() > MAX_POLICY_SIZE {
+                return Err(Status::invalid_argument(format!(
+                    "policy_toml exceeds maximum size of {MAX_POLICY_SIZE} bytes"
+                )));
+            }
+
+            let policy = if req.policy_toml.is_empty() {
+                rauha_common::zone::ZonePolicy::default()
+            } else {
+                let (_toml_zone_type, parsed_policy) =
+                    crate::zone::policy::parse_policy(&req.policy_toml, &self.root)
+                        .map_err(|e| Status::invalid_argument(e.to_string()))?;
+
+                // The gRPC request's zone_type takes precedence over the TOML's
+                // [zone].type field. This allows reusing a policy file across
+                // different zone types.
+                parsed_policy
+            };
+
+            let zone = self
+                .registry
+                .create_zone(&req.name, zone_type, policy)
+                .await
+                .map_err(to_status)?;
+
+            Ok(Response::new(pb::zone::CreateZoneResponse {
+                zone_id: zone.id.to_string(),
+                name: zone.name,
+                state: format!("{:?}", zone.state),
+            }))
         }
-
-        let policy = if req.policy_toml.is_empty() {
-            rauha_common::zone::ZonePolicy::default()
-        } else {
-            let (_toml_zone_type, parsed_policy) =
-                crate::zone::policy::parse_policy(&req.policy_toml, &self.root)
-                    .map_err(|e| Status::invalid_argument(e.to_string()))?;
-
-            // The gRPC request's zone_type takes precedence over the TOML's
-            // [zone].type field. This allows reusing a policy file across
-            // different zone types.
-            parsed_policy
-        };
-
-        let zone = self
-            .registry
-            .create_zone(&req.name, zone_type, policy)
-            .await
-            .map_err(to_status)?;
-
-        Ok(Response::new(pb::zone::CreateZoneResponse {
-            zone_id: zone.id.to_string(),
-            name: zone.name,
-            state: format!("{:?}", zone.state),
-        }))
+        .instrument(span)
+        .await
     }
 
     async fn delete_zone(
         &self,
         request: Request<pb::zone::DeleteZoneRequest>,
     ) -> Result<Response<pb::zone::DeleteZoneResponse>, Status> {
-        emit_rpc_start(&request, "rauha.zone.v1.ZoneService", "DeleteZone");
-        let req = request.into_inner();
-        self.registry
-            .delete_zone(&req.name, req.force)
-            .await
-            .map_err(to_status)?;
-        Ok(Response::new(pb::zone::DeleteZoneResponse {}))
+        let span = rpc_span(&request, "rauha.zone.v1.ZoneService", "DeleteZone");
+        async move {
+            tracing::info!(event.name = "grpc.request.started", "grpc request started");
+            let req = request.into_inner();
+            self.registry
+                .delete_zone(&req.name, req.force)
+                .await
+                .map_err(to_status)?;
+            Ok(Response::new(pb::zone::DeleteZoneResponse {}))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn get_zone(
         &self,
         request: Request<pb::zone::GetZoneRequest>,
     ) -> Result<Response<pb::zone::GetZoneResponse>, Status> {
-        emit_rpc_start(&request, "rauha.zone.v1.ZoneService", "GetZone");
-        let req = request.into_inner();
-        let zone = self.registry.get_zone(&req.name).await.map_err(to_status)?;
+        let span = rpc_span(&request, "rauha.zone.v1.ZoneService", "GetZone");
+        async move {
+            tracing::info!(event.name = "grpc.request.started", "grpc request started");
+            let req = request.into_inner();
+            let zone = self.registry.get_zone(&req.name).await.map_err(to_status)?;
 
-        let containers = self
-            .registry
-            .list_containers(Some(&req.name))
-            .map_err(to_status)?;
+            let containers = self
+                .registry
+                .list_containers(Some(&req.name))
+                .map_err(to_status)?;
 
-        Ok(Response::new(pb::zone::GetZoneResponse {
-            zone: Some(pb::zone::ZoneInfo {
-                id: zone.id.to_string(),
-                name: zone.name,
-                zone_type: format!("{:?}", zone.zone_type),
-                state: format!("{:?}", zone.state),
-                container_count: containers.len() as u32,
-                created_at: zone.created_at.to_rfc3339(),
-            }),
-        }))
+            Ok(Response::new(pb::zone::GetZoneResponse {
+                zone: Some(pb::zone::ZoneInfo {
+                    id: zone.id.to_string(),
+                    name: zone.name,
+                    zone_type: format!("{:?}", zone.zone_type),
+                    state: format!("{:?}", zone.state),
+                    container_count: containers.len() as u32,
+                    created_at: zone.created_at.to_rfc3339(),
+                }),
+            }))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn list_zones(
         &self,
         request: Request<pb::zone::ListZonesRequest>,
     ) -> Result<Response<pb::zone::ListZonesResponse>, Status> {
-        emit_rpc_start(&request, "rauha.zone.v1.ZoneService", "ListZones");
-        let zones = self.registry.list_zones().map_err(to_status)?;
+        let span = rpc_span(&request, "rauha.zone.v1.ZoneService", "ListZones");
+        async move {
+            tracing::info!(event.name = "grpc.request.started", "grpc request started");
+            let zones = self.registry.list_zones().map_err(to_status)?;
 
-        let zone_infos = zones
-            .into_iter()
-            .map(|z| {
-                let container_count = self
-                    .registry
-                    .list_containers(Some(&z.name))
-                    .map(|c| c.len() as u32)
-                    .unwrap_or(0);
-                pb::zone::ZoneInfo {
-                    id: z.id.to_string(),
-                    name: z.name,
-                    zone_type: format!("{:?}", z.zone_type),
-                    state: format!("{:?}", z.state),
-                    container_count,
-                    created_at: z.created_at.to_rfc3339(),
-                }
-            })
-            .collect();
+            let zone_infos = zones
+                .into_iter()
+                .map(|z| {
+                    let container_count = self
+                        .registry
+                        .list_containers(Some(&z.name))
+                        .map(|c| c.len() as u32)
+                        .unwrap_or(0);
+                    pb::zone::ZoneInfo {
+                        id: z.id.to_string(),
+                        name: z.name,
+                        zone_type: format!("{:?}", z.zone_type),
+                        state: format!("{:?}", z.state),
+                        container_count,
+                        created_at: z.created_at.to_rfc3339(),
+                    }
+                })
+                .collect();
 
-        Ok(Response::new(pb::zone::ListZonesResponse {
-            zones: zone_infos,
-        }))
+            Ok(Response::new(pb::zone::ListZonesResponse {
+                zones: zone_infos,
+            }))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn apply_policy(


### PR DESCRIPTION
## Summary

This PR lands the first observability slice for Rauha as the telemetry source:

- Adds TOML `[observability]` config parsing in `rauha-common`.
- Enables JSON-capable `tracing-subscriber` output and initializes `rauhad` from observability config.
- Adds daemon resource fields (`service.name`, `service.version`, `environment`, `host.id`, `host.name`, `pid`) through a process span.
- Adds a daemon-only `process.panic` hook.
- Extends `rauha-evidence` with `trace.id`, `span.id`, and `parent_span.id` serde/projection support.
- Emits structured request-start records for ZoneService calls with request/correlation/trace/span IDs.
- Adds `rauha events --json` line-delimited output and a machine-readable `rauha trace --json` not-implemented response.
- Documents the source-vs-downstream observability boundary in `docs/observability.md` and `CLAUDE.md`.

## Guiding Principles

Structure: daemon logs are JSON-capable by default outside TTY mode, with stable resource and request fields.

Collection: Rauha emits clean stdout JSON and documents the TOML source config. Collector-side enrichment, sidecars, cloud tags, and cold retention stay downstream.

Correlation + Pillars: request-start logs include `request_id`, `correlation_id`, `trace.id`, and `span.id`; evidence events now have standard trace/span field names.

Cost: config schema includes drop/sampling/sink controls and documents current userspace/kernel limits. Enforcement of those controls is intentionally not fully wired in this slice.

## Verification

Local:

```text
cargo build --bin rauhad --bin rauha
cargo check -p rauhad --features otlp
cargo test -p rauha-common -p rauha-evidence -p rauha-cli -p rauhad
```

Linux / syva-dev:

```text
export CARGO_TARGET_DIR=$HOME/rauha-target-linux
cargo build --bin rauhad --bin rauha --bin rauha-shim
cargo test
cd eval/oracle && RAUHA_GRPC_ENDPOINT=http://[::1]:9876 cargo test
```

Results:

```text
rauha sandbox --image alpine:latest -- /bin/echo hi
status: succeeded  exit: 0  (0.2s)
hi

oracle:
test result: ok. 55 passed; 0 failed

workspace:
cargo test passed
```

Sample daemon JSON:

```json
{"message":"grpc request started","event.name":"grpc.request.started","span":{"correlation_id":"0e923fe7-0666-4580-8db9-9fae010f218b","request_id":"0e923fe7-0666-4580-8db9-9fae010f218b","rpc.method":"CreateZone","rpc.service":"rauha.zone.v1.ZoneService","span.id":"0e923fe706664580","trace.id":"0e923fe7066645808db99fae010f218b","name":"grpc.request"}}
```

## Known Gaps

- OTLP is a compile-time no-op feature in this slice; exporter wiring is not implemented yet.
- Request correlation is not threaded through every service/event path yet.
- Drop/sample/rate-limit config is parsed and documented, but not fully enforced.
- `rauha-shim` still emits plain text into the daemon console during sandbox runs because it is a separate process.
