### PR TITLE
Run rauhad with enforcement on kernels missing a hook, and fix policy'd container startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,6 +2562,7 @@ dependencies = [
  "anyhow",
  "aya",
  "aya-log",
+ "aya-obj",
  "block2",
  "chrono",
  "dispatch2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,8 @@ features = ["fs", "mount", "sched", "signal", "user", "net", "hostname", "poll",
 # eBPF (Linux)
 [workspace.dependencies.aya]
 version = "0.13"
+[workspace.dependencies.aya-obj]
+version = "0.2"
 [workspace.dependencies.aya-log]
 version = "0.2"
 

--- a/rauha-common/src/backend.rs
+++ b/rauha-common/src/backend.rs
@@ -63,6 +63,13 @@ pub trait IsolationBackend: Send + Sync {
     /// The name of this backend (e.g., "linux-ebpf", "macos-virt").
     fn name(&self) -> &str;
 
+    /// Why enforcement is degraded, if it is — e.g. LSM hooks the running
+    /// kernel does not expose. `None` means full enforcement. Backends that
+    /// cannot be partially degraded keep the default.
+    fn enforcement_degraded_reason(&self) -> Option<String> {
+        None
+    }
+
     /// Resolve the backend's compact, kernel-side identifier for a zone.
     ///
     /// Kernel enforcement events carry this compact id (not the user-facing

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -2,11 +2,20 @@ use std::path::Path;
 
 /// Fork a child process, set up rootfs, and run the container workload.
 ///
-/// Flow:
-/// 1. Create sync pipe
+/// Flow (two-phase handshake):
+/// 1. Create two sync pipes (setup: child->parent, go: parent->child)
 /// 2. fork()
-/// 3. Child: block on pipe -> pivot_root -> execvp
-/// 4. Parent: write child PID to zone cgroup -> signal pipe -> return PID
+/// 3. Child: privileged setup (unshare/mount/pivot_root) -> signal "setup done"
+///    -> block on "go" -> execvp the workload
+/// 4. Parent: wait for "setup done" -> enroll child PID in zone cgroup
+///    -> signal "go" -> return PID
+///
+/// The privileged bootstrap runs *before* cgroup enrollment, so the eBPF
+/// `capable` hook does not judge rauha's own CAP_SYS_ADMIN setup against the
+/// workload's policy. The untrusted workload (`execvp`) is started only after
+/// enrollment is confirmed, so the TOCTOU enforcement boundary still holds:
+/// no image code ever runs outside the zone. Enrollment failure is fatal —
+/// the workload is never started unenforced (fail closed).
 ///
 /// Note: This uses execvp (not shell exec) - no shell injection possible.
 /// The child process image is replaced entirely by the container command.
@@ -59,8 +68,11 @@ pub fn fork_and_exec(
     let log_dir = PathBuf::from("/run/rauha/containers").join(container_id);
     std::fs::create_dir_all(&log_dir)?;
 
-    // Create sync pipe. OwnedFd closes automatically on drop.
-    let (pipe_rd, pipe_wr) = nix::unistd::pipe()?;
+    // Two sync pipes for the two-phase handshake. OwnedFd closes on drop.
+    //   setup pipe: child -> parent ("privileged setup done, safe to enroll")
+    //   go pipe:    parent -> child ("enrolled, proceed to exec the workload")
+    let (setup_rd, setup_wr) = nix::unistd::pipe()?;
+    let (go_rd, go_wr) = nix::unistd::pipe()?;
 
     // Prepare C strings before fork (allocation not async-signal-safe after fork).
     let c_args = cstring_vec(args, "process.args")?;
@@ -85,29 +97,35 @@ pub fn fork_and_exec(
         std::ffi::CString::new(log_dir.join("stderr.log").to_string_lossy().as_bytes())
             .unwrap_or_default();
 
-    // Convert OwnedFd to raw fds for use across fork.
-    // We manage lifetime manually after fork (child/parent each close their end).
-    let rd_raw = pipe_rd.as_raw_fd();
-    let wr_raw = pipe_wr.as_raw_fd();
+    // Convert OwnedFds to raw fds for use across fork.
+    // We manage lifetime manually after fork (each side closes the ends it
+    // does not use, by dropping the corresponding OwnedFd).
+    let setup_rd_raw = setup_rd.as_raw_fd();
+    let setup_wr_raw = setup_wr.as_raw_fd();
+    let go_rd_raw = go_rd.as_raw_fd();
+    let go_wr_raw = go_wr.as_raw_fd();
 
     // Fork.
     match unsafe { unistd::fork() }? {
         ForkResult::Child => {
-            // Drop the write end (closes it).
-            drop(pipe_wr);
-
-            // Block until parent confirms cgroup enrollment.
-            let mut buf = [0u8; 1];
-            let _ = nix::unistd::read(rd_raw, &mut buf);
-            // Drop the read end.
-            drop(pipe_rd);
+            // Close the pipe ends this process does not use.
+            drop(setup_rd);
+            drop(go_wr);
 
             // New session.
             let _ = nix::unistd::setsid();
 
-            // Redirect stdout/stderr to log files.
+            // Redirect stdout/stderr to log files. Must happen before pivot_root
+            // while /run/rauha/... is still reachable on the host filesystem.
             // Uses raw open() with pre-allocated CStrings — async-signal-safe.
             redirect_stdio_raw(&stdout_log, &stderr_log);
+
+            // --- Privileged container bootstrap, BEFORE cgroup enrollment ---
+            // The child is not yet a zone member here, so the eBPF `capable`
+            // hook sees no zone (lookup_caller_zone -> None -> allow) and does
+            // not judge these CAP_SYS_ADMIN operations against the workload's
+            // policy. No image code runs in this window — only this fixed,
+            // trusted setup sequence, after which we block until enrolled.
 
             // Enter a new mount namespace and make all mounts private.
             // pivot_root requires: (1) own mount namespace, (2) private root mount.
@@ -148,6 +166,27 @@ pub fn fork_and_exec(
                 let _ = nix::unistd::sethostname(h);
             }
 
+            // Signal the parent that privileged setup is complete and it is
+            // safe to enroll us in the zone cgroup.
+            let _ = nix::unistd::write(unsafe { BorrowedFd::borrow_raw(setup_wr_raw) }, &[1u8]);
+            drop(setup_wr);
+
+            // Block until the parent confirms cgroup enrollment. From here on
+            // the process is inside the enforcement boundary, so the workload
+            // exec below is fully subject to zone policy.
+            let mut buf = [0u8; 1];
+            let n = nix::unistd::read(go_rd_raw, &mut buf);
+            drop(go_rd);
+            // The "go" pipe closing without a byte means the parent could not
+            // enroll us — refuse to run the workload unenforced (fail closed).
+            if !matches!(n, Ok(1)) {
+                let msg = b"cgroup enrollment failed; refusing to start workload unenforced\n";
+                unsafe {
+                    let _ = libc::write(2, msg.as_ptr() as _, msg.len());
+                    libc::_exit(125);
+                }
+            }
+
             // Set environment using libc directly — bypasses Rust's env mutex.
             // std::env::set_var/remove_var are NOT async-signal-safe (they hold
             // a global lock that may be held by the parent process's other threads).
@@ -171,21 +210,46 @@ pub fn fork_and_exec(
             }
         }
         ForkResult::Parent { child } => {
-            // Drop read end (closes it).
-            drop(pipe_rd);
+            // Close the pipe ends this process does not use.
+            drop(setup_wr);
+            drop(go_rd);
 
             let child_pid = child.as_raw() as u32;
+            let child_p = nix::unistd::Pid::from_raw(child_pid as i32);
 
-            // Enroll child in zone cgroup.
-            let cgroup_path = format!("/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs");
-            if let Err(e) = std::fs::write(&cgroup_path, child_pid.to_string()) {
-                tracing::warn!(%e, cgroup = cgroup_path, "failed to enroll child in cgroup");
+            // Wait for the child to finish privileged setup before enrolling it,
+            // so its CAP_SYS_ADMIN bootstrap is not judged against zone policy.
+            // A read of 1 byte means setup succeeded; EOF (0) means the child
+            // died during setup (it already wrote its own error to stderr).
+            let mut buf = [0u8; 1];
+            let setup_ok = matches!(nix::unistd::read(setup_rd_raw, &mut buf), Ok(1));
+            drop(setup_rd);
+            if !setup_ok {
+                drop(go_wr);
+                let _ = nix::sys::wait::waitpid(child_p, None);
+                anyhow::bail!(
+                    "container {container_id} failed during pre-enrollment setup \
+                     (see container stderr)"
+                );
             }
 
-            // Signal child to proceed (unblock from sync pipe).
-            let _ = nix::unistd::write(unsafe { BorrowedFd::borrow_raw(wr_raw) }, &[1u8]);
-            // Drop write end (closes it).
-            drop(pipe_wr);
+            // Enroll child in zone cgroup. This MUST succeed: a workload running
+            // outside the cgroup gets no eBPF enforcement. On failure, kill the
+            // child and report the error rather than signaling "go" — fail closed.
+            let cgroup_path = format!("/sys/fs/cgroup/rauha.slice/zone-{zone_name}/cgroup.procs");
+            if let Err(e) = std::fs::write(&cgroup_path, child_pid.to_string()) {
+                let _ = nix::sys::signal::kill(child_p, nix::sys::signal::Signal::SIGKILL);
+                let _ = nix::sys::wait::waitpid(child_p, None);
+                drop(go_wr);
+                anyhow::bail!(
+                    "failed to enroll container {container_id} in zone cgroup \
+                     {cgroup_path}: {e}; refusing to start workload unenforced"
+                );
+            }
+
+            // Signal the child to proceed to exec — it is now inside the boundary.
+            let _ = nix::unistd::write(unsafe { BorrowedFd::borrow_raw(go_wr_raw) }, &[1u8]);
+            drop(go_wr);
 
             tracing::info!(pid = child_pid, container = container_id, "child forked");
             Ok(child_pid)

--- a/rauha-shim/src/container.rs
+++ b/rauha-shim/src/container.rs
@@ -30,6 +30,7 @@ pub fn fork_and_exec(
     use oci_spec::runtime::Spec;
     use std::ffi::CString;
     use std::os::fd::{AsRawFd, BorrowedFd};
+    use std::os::unix::ffi::OsStrExt;
     use std::path::PathBuf;
 
     let spec: Spec = serde_json::from_str(spec_json)?;
@@ -97,6 +98,12 @@ pub fn fork_and_exec(
         std::ffi::CString::new(log_dir.join("stderr.log").to_string_lossy().as_bytes())
             .unwrap_or_default();
 
+    // Pre-allocate pivot_root paths as CStrings BEFORE fork — the child path
+    // must not allocate (fork-safety invariant).
+    let rootfs_cstr = CString::new(rootfs.as_os_str().as_bytes()).unwrap_or_default();
+    let pivot_old_cstr =
+        CString::new(rootfs.join(".pivot_old").as_os_str().as_bytes()).unwrap_or_default();
+
     // Convert OwnedFds to raw fds for use across fork.
     // We manage lifetime manually after fork (each side closes the ends it
     // does not use, by dropping the corresponding OwnedFd).
@@ -130,31 +137,35 @@ pub fn fork_and_exec(
             // Enter a new mount namespace and make all mounts private.
             // pivot_root requires: (1) own mount namespace, (2) private root mount.
             // Without MS_PRIVATE|MS_REC, inherited shared mounts cause EINVAL.
-            if let Err(e) = nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS) {
-                let msg = format!("unshare(CLONE_NEWNS) failed: {e}\n");
+            // Error reporting in the child must be async-signal-safe: static
+            // byte messages + libc::write, never format!/alloc. The specific
+            // errno is dropped; the failing operation is still identifiable.
+            if nix::sched::unshare(nix::sched::CloneFlags::CLONE_NEWNS).is_err() {
                 unsafe {
+                    let msg = b"rauha-shim: unshare(CLONE_NEWNS) failed\n";
                     let _ = libc::write(2, msg.as_ptr() as _, msg.len());
                     libc::_exit(1);
                 }
             }
             // Make all mounts private — required for pivot_root to work.
-            if let Err(e) = nix::mount::mount(
+            if nix::mount::mount(
                 None::<&str>,
                 "/",
                 None::<&str>,
                 nix::mount::MsFlags::MS_PRIVATE | nix::mount::MsFlags::MS_REC,
                 None::<&str>,
-            ) {
-                let msg = format!("mount(MS_PRIVATE) failed: {e}\n");
+            )
+            .is_err()
+            {
                 unsafe {
+                    let msg = b"rauha-shim: mount(MS_PRIVATE) failed\n";
                     let _ = libc::write(2, msg.as_ptr() as _, msg.len());
                     libc::_exit(1);
                 }
             }
 
             // pivot_root into the container rootfs.
-            if let Err(e) = do_pivot_root(&rootfs) {
-                let msg = format!("pivot_root failed: {e}\n");
+            if let Err(msg) = do_pivot_root(&rootfs_cstr, &pivot_old_cstr) {
                 unsafe {
                     let _ = libc::write(2, msg.as_ptr() as _, msg.len());
                     libc::_exit(1);
@@ -202,9 +213,9 @@ pub fn fork_and_exec(
             let _ = nix::unistd::chdir(cwd_cstr.as_c_str());
 
             // Replace process with container command (execvp, no shell involved).
-            let err = nix::unistd::execvp(&c_args[0], &c_args);
-            let msg = format!("execvp failed: {err:?}\n");
+            let _ = nix::unistd::execvp(&c_args[0], &c_args);
             unsafe {
+                let msg = b"rauha-shim: execvp failed\n";
                 let _ = libc::write(2, msg.as_ptr() as _, msg.len());
                 libc::_exit(127);
             }
@@ -248,8 +259,18 @@ pub fn fork_and_exec(
             }
 
             // Signal the child to proceed to exec — it is now inside the boundary.
-            let _ = nix::unistd::write(unsafe { BorrowedFd::borrow_raw(go_wr_raw) }, &[1u8]);
+            let signaled = nix::unistd::write(unsafe { BorrowedFd::borrow_raw(go_wr_raw) }, &[1u8]);
             drop(go_wr);
+            // A failed/short write (e.g. EPIPE) means the child went away between
+            // "setup done" and "go" — it will never exec the workload. Reap it
+            // and report failure rather than claiming a container started.
+            if !matches!(signaled, Ok(1)) {
+                let _ = nix::sys::wait::waitpid(child_p, None);
+                anyhow::bail!(
+                    "container {container_id} exited before workload exec \
+                     (enrollment signal not delivered)"
+                );
+            }
 
             tracing::info!(pid = child_pid, container = container_id, "child forked");
             Ok(child_pid)
@@ -334,28 +355,44 @@ pub fn try_wait(pid: u32) -> Option<i32> {
 }
 
 /// Perform pivot_root to change the container's root filesystem.
+///
+/// Runs in the post-fork child, so it must be async-signal-safe: no heap
+/// allocation. Paths are pre-allocated `CStr`s; directory create/remove use
+/// `libc` directly (not `std::fs`); errors are returned as static `&str`
+/// messages for the caller to `libc::write` + `_exit`.
 #[cfg(target_os = "linux")]
-fn do_pivot_root(new_root: &Path) -> anyhow::Result<()> {
+fn do_pivot_root(
+    new_root: &std::ffi::CStr,
+    old_root: &std::ffi::CStr,
+) -> Result<(), &'static [u8]> {
     use nix::mount::{mount, umount2, MntFlags, MsFlags};
 
     // Bind-mount new_root onto itself (required by pivot_root).
     mount(
         Some(new_root),
         new_root,
-        None::<&str>,
+        None::<&std::ffi::CStr>,
         MsFlags::MS_BIND | MsFlags::MS_REC,
-        None::<&str>,
-    )?;
+        None::<&std::ffi::CStr>,
+    )
+    .map_err(|_| &b"rauha-shim: bind-mount rootfs failed\n"[..])?;
 
-    let old_root = new_root.join(".pivot_old");
-    std::fs::create_dir_all(&old_root)?;
+    // Create the pivot-old mountpoint (ignore EEXIST). libc::mkdir is
+    // async-signal-safe; std::fs would allocate.
+    unsafe {
+        libc::mkdir(old_root.as_ptr(), 0o755);
+    }
 
-    nix::unistd::pivot_root(new_root, &old_root)?;
-    nix::unistd::chdir("/")?;
+    nix::unistd::pivot_root(new_root, old_root)
+        .map_err(|_| &b"rauha-shim: pivot_root failed\n"[..])?;
+    nix::unistd::chdir(c"/").map_err(|_| &b"rauha-shim: chdir(/) failed\n"[..])?;
 
     // Unmount old root.
-    umount2("/.pivot_old", MntFlags::MNT_DETACH)?;
-    std::fs::remove_dir("/.pivot_old").ok();
+    umount2(c"/.pivot_old", MntFlags::MNT_DETACH)
+        .map_err(|_| &b"rauha-shim: umount old root failed\n"[..])?;
+    unsafe {
+        libc::rmdir(c"/.pivot_old".as_ptr());
+    }
 
     Ok(())
 }

--- a/rauhad/Cargo.toml
+++ b/rauhad/Cargo.toml
@@ -31,6 +31,7 @@ hex = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 aya = { workspace = true }
+aya-obj = { workspace = true }
 aya-log = { workspace = true }
 rauha-ebpf-common = { workspace = true }
 nix = { workspace = true }

--- a/rauhad/src/backend/linux/ebpf.rs
+++ b/rauhad/src/backend/linux/ebpf.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 use aya::programs::Lsm;
 use aya::{Bpf, BpfLoader, Btf};
+use aya_obj::btf::BtfKind;
 use rauha_common::error::{RauhaError, Result};
 use rauha_ebpf_common::offsets::{
     object_sha256, offsets_sidecar_path, parse_offsets_sidecar, resolve_kernel_offsets_map,
@@ -151,10 +152,33 @@ impl EbpfManager {
 
         let mut program_fds = HashMap::new();
 
-        // Attach every declared LSM program. Partial enforcement is not safe:
-        // if a kernel lacks a hook we rely on, or an individual attach fails,
-        // Rauha must refuse to start rather than run with a missing boundary.
+        // Attach every declared LSM program that this kernel can support.
+        //
+        // Policy: a hook the running kernel does not expose as a BPF-LSM attach
+        // point is skipped (best-effort, degraded enforcement). Any *other*
+        // failure — the program missing from our own object, or the kernel
+        // rejecting an attach for a hook it does expose — is still fatal: we
+        // refuse to run with a boundary that should exist but silently broke.
+        let mut skipped_hooks: Vec<&str> = Vec::new();
+
         for &(prog_name, hook_name) in LSM_PROGRAMS {
+            // Probe the kernel BTF for `bpf_lsm_<hook>`. If the kernel was not
+            // built exposing this LSM hook to BPF (e.g. cgroup_attach_task is
+            // absent on many stock kernels), skip it gracefully rather than
+            // failing the whole daemon.
+            if btf
+                .id_by_type_name_kind(&format!("bpf_lsm_{hook_name}"), BtfKind::Func)
+                .is_err()
+            {
+                tracing::warn!(
+                    program = prog_name,
+                    hook = hook_name,
+                    "kernel does not expose this BPF-LSM hook; skipping (degraded enforcement)"
+                );
+                skipped_hooks.push(hook_name);
+                continue;
+            }
+
             let prog: &mut Lsm = match bpf.program_mut(prog_name) {
                 Some(p) => match p.try_into() {
                     Ok(lsm) => lsm,
@@ -198,20 +222,46 @@ impl EbpfManager {
             );
         }
 
-        if program_fds.len() != LSM_PROGRAMS.len() {
+        // Every hook the kernel *does* expose must have attached — the loop
+        // hard-fails otherwise — so this should always hold. Kept as a
+        // defensive invariant against future refactors of the loop above.
+        let expected = LSM_PROGRAMS.len() - skipped_hooks.len();
+        if program_fds.len() != expected {
             return Err(RauhaError::EbpfError {
                 message: format!(
-                    "partial LSM attachment: attached {} of {} required programs",
+                    "partial LSM attachment: attached {} of {} attachable programs",
                     program_fds.len(),
-                    LSM_PROGRAMS.len()
+                    expected
                 ),
                 hint: "restart rauhad after fixing kernel BPF-LSM support".into(),
             });
         }
 
+        // Refuse to run with zero enforcement — that is indistinguishable from
+        // having no sandbox at all, and is never what the operator wants.
+        if program_fds.is_empty() {
+            return Err(RauhaError::EbpfError {
+                message: "no LSM hooks could be attached on this kernel".into(),
+                hint: "kernel exposes none of Rauha's BPF-LSM hooks; check \
+                       CONFIG_BPF_LSM=y and `lsm=bpf` in the kernel cmdline"
+                    .into(),
+            });
+        }
+
+        if !skipped_hooks.is_empty() {
+            tracing::warn!(
+                skipped = ?skipped_hooks,
+                attached = program_fds.len(),
+                total = LSM_PROGRAMS.len(),
+                "running with DEGRADED enforcement: some LSM hooks are \
+                 unavailable on this kernel"
+            );
+        }
+
         tracing::info!(
             attached = program_fds.len(),
             total = LSM_PROGRAMS.len(),
+            skipped = skipped_hooks.len(),
             pin_path = %pin_path.display(),
             "eBPF programs loaded"
         );

--- a/rauhad/src/backend/linux/ebpf.rs
+++ b/rauhad/src/backend/linux/ebpf.rs
@@ -49,6 +49,9 @@ pub struct EbpfManager {
     // (which owns the actual fds). Do not reorder these fields.
     bpf: Bpf,
     pin_path: PathBuf,
+    /// LSM hooks the running kernel does not expose, skipped at load time.
+    /// Non-empty means enforcement is active but degraded.
+    skipped_hooks: Vec<String>,
     /// Program fds recorded after attach, keyed by program name.
     /// Used in health_check to verify programs are still loaded.
     ///
@@ -269,6 +272,7 @@ impl EbpfManager {
         let mut mgr = Self {
             bpf,
             pin_path,
+            skipped_hooks: skipped_hooks.iter().map(|h| h.to_string()).collect(),
             program_fds,
         };
 
@@ -277,6 +281,12 @@ impl EbpfManager {
         mgr.verify_offset_self_test()?;
 
         Ok(mgr)
+    }
+
+    /// LSM hooks skipped because the running kernel does not expose them.
+    /// Non-empty means enforcement is active but degraded.
+    pub fn skipped_hooks(&self) -> &[String] {
+        &self.skipped_hooks
     }
 
     /// Take ownership of the ENFORCEMENT_EVENTS ring buffer map.

--- a/rauhad/src/backend/linux/enforcer.rs
+++ b/rauhad/src/backend/linux/enforcer.rs
@@ -95,6 +95,18 @@ impl LinuxEnforcer {
         self.event_tx.clone()
     }
 
+    /// LSM hooks the running kernel does not expose (skipped at load). Non-empty
+    /// means kernel enforcement is active but degraded.
+    pub(super) fn skipped_hooks(&self) -> Vec<String> {
+        match lock_backend(&self.ebpf, "linux_enforcer.ebpf") {
+            Ok(guard) => guard
+                .as_ref()
+                .map(|m| m.skipped_hooks().to_vec())
+                .unwrap_or_default(),
+            Err(_) => Vec::new(),
+        }
+    }
+
     pub(super) fn set_zone_policy(&self, zone_id: u32, policy: &ZonePolicy) -> Result<()> {
         self.with_bpf("policy enforcement", |bpf| {
             MapManager::set_zone_policy(bpf, zone_id, policy)

--- a/rauhad/src/backend/linux/mod.rs
+++ b/rauhad/src/backend/linux/mod.rs
@@ -1023,6 +1023,15 @@ impl IsolationBackend for LinuxBackend {
         "linux-ebpf"
     }
 
+    fn enforcement_degraded_reason(&self) -> Option<String> {
+        let skipped = self.enforcer.skipped_hooks();
+        if skipped.is_empty() {
+            None
+        } else {
+            Some(format!("lsm_hooks_unavailable:{}", skipped.join(",")))
+        }
+    }
+
     fn kernel_zone_id(&self, zone: &ZoneHandle) -> Option<u32> {
         // The compact id is the same value stamped on enforcement events as
         // `caller_zone`. A poisoned lock or unmapped zone yields None — callers

--- a/rauhad/src/main.rs
+++ b/rauhad/src/main.rs
@@ -75,14 +75,25 @@ async fn main() -> anyhow::Result<()> {
         rauha_common::zone::IsolationModel::SyscallPolicy
         | rauha_common::zone::IsolationModel::HardwareBoundary => EnforcementMode::Enforcing,
     };
-    RuntimeEventBuilder::new(
+    // Enforcement may be active but degraded (e.g. a kernel that doesn't expose
+    // every LSM hook). Surface that as structured state so consumers can tell
+    // full from partial enforcement — not only by reading log text.
+    let degraded_reason = backend.enforcement_degraded_reason();
+    let mut backend_event = RuntimeEventBuilder::new(
         event_name::BACKEND_SELECTED,
         EventKind::Backend,
         EventOutcome::Succeeded,
     )
     .backend(backend.name(), platform, enforcement_mode)
-    .trust_level(TrustLevel::Complete)
-    .emit();
+    .trust_level(if degraded_reason.is_some() {
+        TrustLevel::Partial
+    } else {
+        TrustLevel::Complete
+    });
+    if let Some(reason) = degraded_reason {
+        backend_event = backend_event.degraded_reason(reason);
+    }
+    backend_event.emit();
 
     // Create image service.
     let content_store = Arc::new(


### PR DESCRIPTION
Two independent runtime/enforcement fixes that surfaced while bringing rauhad up with live eBPF enforcement on a stock kernel (Ubuntu, 6.8). Each is its own commit.

## 1. Degraded enforcement when the kernel lacks a BPF-LSM hook (`ba2eb6b`)
The eBPF loader required all 7 LSM hooks to attach or refused to start. Stock kernels don't expose every hook as a BPF-LSM attach point — `cgroup_attach_task` (`bpf_lsm_cgroup_attach_task`) is absent on many — so rauhad couldn't start at all, contradicting the documented *"unsupported hooks are skipped gracefully at load time"* behavior.

Now: probe the kernel BTF for each `bpf_lsm_<hook>` before load; if absent, skip with a `DEGRADED` warning and continue. **Any other** failure (program missing from our object, or attach rejected for a hook the kernel *does* expose) stays fatal, and attaching **zero** hooks stays fatal — we never run a sandbox with no enforcement. Adds `aya-obj` for `BtfKind` (same version `aya` already pins).

## 2. Container privileged setup before cgroup enrollment (`5e01374`)
The child was enrolled in the zone cgroup **before** running `unshare(CLONE_NEWNS)`/`mount`/`pivot_root`, so the `capable` LSM hook judged rauha's own bootstrap against the *workload's* capability policy. Under a restrictive policy (`standard.toml` withholds `CAP_SYS_ADMIN`) the bootstrap was denied — `unshare(CLONE_NEWNS) failed: EPERM` — and the container never started.

Now: a **two-phase fork handshake** — the child does privileged setup first (not yet a zone member → `capable` allows), signals "setup done", the parent enrolls it in the cgroup, signals "go", and only then does the child `exec` the workload. The untrusted workload still runs only after enrollment, so the TOCTOU boundary holds. Enrollment failure is now **fatal** (kill child, return error) instead of warning and running the workload unenforced (fail closed).

## Verification (syva-dev, kernel 6.8, `lsm=…,bpf`)
- rauhad starts with **6/7 LSM hooks** attached (`cgroup_attach_task` skipped, DEGRADED warning); oracle **55/55**.
- A zone with `standard.toml` now **starts a container**; a workload's own `hostname`/`unshare -m` is still **denied** (`zone.mount.denied`, `context=21` = `CAP_SYS_ADMIN`).
- `cargo test -p rauha-shim` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)