### PR TITLE
ci: run on arc-arm64 self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   linux-build:
     name: Linux build
-    runs-on: ubuntu-latest
+    runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install native dependencies
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config protobuf-compiler build-essential
+
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Check Linux daemon and CLI
         run: cargo check -p rauhad -p rauha-cli -p rauha-common -p rauha-enforcer-api


### PR DESCRIPTION
Org-wide move off GitHub-hosted runners onto the org's free ARC pool (context: false-systems/false-infra#5). This PR's own CI executes on arc-arm64 — green checks prove the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)